### PR TITLE
Feature: Added checkbox component and theme customizations for Kystverket colors

### DIFF
--- a/src/components/Checkbox/Checkbox.stories.ts
+++ b/src/components/Checkbox/Checkbox.stories.ts
@@ -1,0 +1,20 @@
+import React from "react";
+import type { Meta, StoryObj } from '@storybook/react';
+import { Checkbox } from "./Checkbox";
+
+const meta: Meta<typeof Checkbox> = {
+    title: "Components/Checkbox",
+    component: Checkbox,
+    tags: ['autodocs'],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Checkbox>;
+
+export const Primary: Story = {
+    args: {
+        label: "Toggle me",
+    },
+};
+

--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -1,0 +1,34 @@
+import { Checkbox as ChakraCheckbox } from "@chakra-ui/react"
+import React from "react"
+import { colors } from "../..";
+
+type CheckboxSize = "small" | "medium" | "large";
+
+interface CheckboxProps {
+    isChecked?: boolean
+    isDisabled?: boolean
+    label: string,
+    size: CheckboxSize,
+    onChange?: (event: React.ChangeEvent<HTMLInputElement>) => void;
+}
+
+const translateCheckboxSize = (checkboxSize: CheckboxSize): string => {
+    switch (checkboxSize) {
+        case "large":
+            return "lg";
+        case "medium":
+            return "md";
+        case "small":
+            return "sm";
+    }
+}
+
+export const Checkbox = ({ label, size, ...props }: CheckboxProps) => (
+    <ChakraCheckbox
+        {...props}
+        size={translateCheckboxSize(size)}
+        colorScheme={"colorSchemes.navy"}
+    >
+        {label}
+    </ChakraCheckbox>
+)

--- a/src/components/StyrbordProvider/StyrbordProvider.tsx
+++ b/src/components/StyrbordProvider/StyrbordProvider.tsx
@@ -1,13 +1,39 @@
 import '../../styles/variables.css';
 
 import React from 'react';
-import { ChakraProvider, ChakraProviderProps } from "@chakra-ui/react";
+import { ChakraProvider, ChakraProviderProps, extendTheme } from "@chakra-ui/react";
+
+const theme = extendTheme({
+    colors: {
+        navy: "#000667",
+        rust: "#ff451f",
+        sky: "#a9e5fb",
+        sand: "#f9f6f3",
+        sea: "#0596cb",
+        grey: "#5d5d5d",
+        forest: "#3ba460",
+        colorSchemes: {
+            navy: {
+                100: "#aeb2ff",
+                200: "#858cff",
+                300: "#5c66ff",
+                400: "#333fff",
+                500: "#0b19ff",
+                600: "#000de1",
+                700: "#000bb8",
+                800: "#000890",
+                900: "#000667",
+            }
+        }
+    },
+});
+
 /**
  * StyrbordProvider er komponenten som gir de andre komponentene riktig tema og stil.
  * Se https://chakra-ui.com/getting-started/cra-guide#2-provider-setup.
  */
 export const StyrbordProvider = ({ children, ...props }: ChakraProviderProps) => (
-    <ChakraProvider {...props}>
+    <ChakraProvider {...props} theme={theme}>
         {children}
     </ChakraProvider>
 );


### PR DESCRIPTION
- Added checkbox component that wraps Chakra checkbox. Supports only limited number of props. 

- Added theme for kystverket colors scheme. The colors can either be specified as gradient scheme with strengths provided or direct colors. Might be easier to workwith direct colors for now since we have these available. The checkbox component needs a gradient scheme for custom colors work, so I have added one colorscheme that this component uses. Suggestion is to have gradient color schemes a nested property in the theme and use that where ever needed (good idea, bad idea?). 