### PR TITLE
MS-339 Oppdater body-stiler for maritim sikring

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kystverket/styrbord",
-  "version": "0.200.33",
+  "version": "0.200.34",
   "description": "",
   "type": "module",
   "exports": {

--- a/src/components/kystverket/Typography/typography.module.css
+++ b/src/components/kystverket/Typography/typography.module.css
@@ -85,6 +85,20 @@
   font-weight: var(--font-weight-bold);
 }
 
+.body-xxl {
+  font-size: var(--typescale-body-XXlarge-font-size);
+  line-height: var(--typescale-body-XXlarge-line-height);
+  letter-spacing: var(--typescale-body-XXlarge-letter-spacing);
+  font-weight: var(--font-weight-regular);
+}
+
+.body-xl {
+  font-size: var(--typescale-body-Xlarge-font-size);
+  line-height: var(--typescale-body-Xlarge-line-height);
+  letter-spacing: var(--typescale-body-Xlarge-letter-spacing);
+  font-weight: var(--font-weight-regular);
+}
+
 .body-lg {
   font-size: var(--typescale-body-large-font-size);
   line-height: var(--typescale-body-large-line-height);
@@ -198,4 +212,12 @@
 .accent-sm-strong {
   composes: label-sm;
   font-weight: var(--font-weight-bold);
+}
+
+.accentColor {
+  color: var(--color-accent-text-default);
+}
+
+.margin {
+  margin-bottom: var(--spacing-20);
 }

--- a/src/components/kystverket/Typography/typography.stories.tsx
+++ b/src/components/kystverket/Typography/typography.stories.tsx
@@ -39,6 +39,20 @@ const defaultProps: BoxProps = {
       <Body size="lg">Body Large</Body>
       <Body size="md">Body Medium</Body>
       <Body size="sm">Body Small</Body>
+      <Body size="xxl">Body XXLarge</Body>
+      <Body size="xl">Body XLarge</Body>
+      <Body size="lg">Body Large</Body>
+      <Body size="lg" margin>
+        Body Large margin
+      </Body>
+      <Body size="lg" strong>
+        Body Large medium weight
+      </Body>
+      <Body size="lg" color="accent">
+        Body Large accent
+      </Body>
+      <Body size="md">Body Medium</Body>
+      <Body size="sm">Body Small</Body>
       <Label size="xl" strong>
         Label XL Strong
       </Label>

--- a/src/components/kystverket/Typography/typography.tsx
+++ b/src/components/kystverket/Typography/typography.tsx
@@ -13,9 +13,11 @@ export type HeaderTypographyProps = TypographyProps & {
 };
 
 export type BodyTypographyProps = TypographyProps & {
-  size?: 'sm' | 'md' | 'lg';
+  size?: 'sm' | 'md' | 'lg' | 'xl' | 'xxl';
   strong?: boolean;
   inline?: boolean;
+  margin?: boolean;
+  color?: 'accent' | 'neutral';
 };
 
 export type LabelTypographyProps = TypographyProps & {
@@ -60,12 +62,14 @@ export const Title = ({ level, size, className, children }: HeaderTypographyProp
   );
 };
 
-export const Body = ({ inline, strong, size, className, children }: BodyTypographyProps) => {
+export const Body = ({ inline, strong, size, color, margin, className, children }: BodyTypographyProps) => {
   const classes = buildTypographyClasses({
     type: 'body',
     size,
     strong,
     inline,
+    color,
+    margin,
     className,
   });
 

--- a/src/components/kystverket/Typography/typography.util.ts
+++ b/src/components/kystverket/Typography/typography.util.ts
@@ -1,14 +1,18 @@
 import typography from './typography.module.css';
 
-export type TypographyPrefix = 'display' | 'headline' | 'title' | 'body' | 'label' | 'accent';
+export type TypographyPrefix = 'display' | 'headline' | 'title' | 'body' | 'label' | 'accent' | 'paragraph';
 
-export type AllSizes = 'sm' | 'md' | 'lg' | 'xl';
+export type AllSizes = 'sm' | 'md' | 'lg' | 'xl' | 'xxl';
+
+export type TypographyColor = 'accent' | 'neutral';
 
 type BuildTypographyProps = {
   type: TypographyPrefix;
   size?: AllSizes;
   strong?: boolean;
   inline?: boolean;
+  color?: TypographyColor;
+  margin?: boolean;
   className?: string;
 };
 
@@ -17,12 +21,16 @@ export const buildTypographyClasses = ({
   size = 'md',
   strong = false,
   inline = false,
+  color = 'neutral',
+  margin = false,
   className,
 }: BuildTypographyProps): string => {
   return [
     typography[type],
     typography[`${type}-${size}${strong ? '-strong' : ''}`],
     inline ? typography.inline : '',
+    color === 'accent' ? typography.accentColor : '',
+    margin ? typography.margin : '',
     className ?? '',
   ].join(' ');
 };

--- a/src/css/kyv-tokens.css
+++ b/src/css/kyv-tokens.css
@@ -291,6 +291,12 @@
   --typescale-title-small-font-size: 1rem;
   --typescale-title-small-line-height: 1.5rem;
   --typescale-title-small-letter-spacing: 0.009999999776482582rem;
+  --typescale-body-XXlarge-font-size: 1.375rem;
+  --typescale-body-XXlarge-line-height: 2rem;
+  --typescale-body-XXlarge-letter-spacing: 0rem;
+  --typescale-body-Xlarge-font-size: 1.25rem;
+  --typescale-body-Xlarge-line-height: 2rem;
+  --typescale-body-Xlarge-letter-spacing: 0rem;
   --typescale-body-large-font-size: 1.125rem;
   --typescale-body-large-line-height: 1.75rem;
   --typescale-body-large-letter-spacing: 0rem;


### PR DESCRIPTION
Legg til ekstra valg for body for å passe med endra tekststiler for maritim sikring.
- Lagt til størrelse xl og xxl
- Lag til valg for margin etter body
- Lagt til valg for kystverket blå farge på tekst
(styling henta frå Figma, Core UI Kit: https://www.figma.com/design/m4XMnBxEGb002JGxdsmLWG/Kystverket-Core-UI-Kit?node-id=10088-11935&t=UZmAAvSVr5FxLgjj-4)