### PR TITLE
SAK-370: Oppdater input i styrbord

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kystverket/styrbord",
-  "version": "0.300.10",
+  "version": "0.300.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@kystverket/styrbord",
-      "version": "0.300.10",
+      "version": "0.300.11",
       "license": "ISC",
       "dependencies": {
         "date-fns": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kystverket/styrbord",
-  "version": "0.300.10",
+  "version": "0.300.11",
   "description": "",
   "type": "module",
   "exports": {

--- a/src/components/designsystemet/NumberInput/NumberInput.tsx
+++ b/src/components/designsystemet/NumberInput/NumberInput.tsx
@@ -16,7 +16,7 @@ export interface NumberInputProps {
   error?: string | boolean | null;
   disabled?: boolean;
   readOnly?: boolean;
-  inputMode?: 'tel' | 'numeric' | 'decimal';
+  inputMode?: 'numeric' | 'decimal';
   prefix?: string;
   suffix?: string;
   min?: number;
@@ -50,7 +50,7 @@ export const NumberInput = ({ size = 'full', className, align = 'left', ...props
       error={props.error}
       prefix={props.prefix}
       suffix={props.suffix}
-      type="numeric"
+      type="number"
       min={props.min}
       max={props.max}
     />

--- a/src/components/designsystemet/NumberInput/NumberInput.tsx
+++ b/src/components/designsystemet/NumberInput/NumberInput.tsx
@@ -50,7 +50,7 @@ export const NumberInput = ({ size = 'full', className, align = 'left', ...props
       error={props.error}
       prefix={props.prefix}
       suffix={props.suffix}
-      type="number"
+      type="text"
       min={props.min}
       max={props.max}
     />

--- a/src/components/designsystemet/NumberInput/NumberInput.tsx
+++ b/src/components/designsystemet/NumberInput/NumberInput.tsx
@@ -25,7 +25,13 @@ export interface NumberInputProps {
   size?: InputSize;
 }
 
-export const NumberInput = ({ size = 'full', className, align = 'left', ...props }: NumberInputProps) => {
+export const NumberInput = ({
+  size = 'full',
+  inputMode = 'numeric',
+  className,
+  align = 'left',
+  ...props
+}: NumberInputProps) => {
   return (
     <Textfield
       className={[className, inputSizeClass(size), classes['align-' + align]].join(' ')}
@@ -46,7 +52,7 @@ export const NumberInput = ({ size = 'full', className, align = 'left', ...props
       onChange={(event) => {
         props.onChange?.(event.target.value ? parseFloat(event.target.value) : undefined);
       }}
-      inputMode={props.inputMode}
+      inputMode={inputMode}
       error={props.error}
       prefix={props.prefix}
       suffix={props.suffix}

--- a/src/components/designsystemet/TextArea/TextArea.override.scss
+++ b/src/components/designsystemet/TextArea/TextArea.override.scss
@@ -1,4 +1,7 @@
 .ds-input {
   --dsc-input-padding: var(--spacing-4) var(--spacing-4) var(--spacing-4) var(--spacing-16);
+}
+
+.ds-input:is(textarea) {
   min-height: 165px !important;
 }

--- a/src/components/designsystemet/TextArea/TextArea.override.scss
+++ b/src/components/designsystemet/TextArea/TextArea.override.scss
@@ -1,3 +1,4 @@
 .ds-input {
   --dsc-input-padding: var(--spacing-4) var(--spacing-4) var(--spacing-4) var(--spacing-16);
+  min-height: 165px !important;
 }

--- a/src/components/designsystemet/TextArea/TextArea.stories.tsx
+++ b/src/components/designsystemet/TextArea/TextArea.stories.tsx
@@ -60,10 +60,19 @@ export const WithError: Story = {
   },
 };
 
-export const ManyRows: Story = {
+export const ReadOnly: Story = {
   args: {
     ...defaultArgs,
-    rows: 10,
+    error: false,
+    readOnly: true,
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    ...defaultArgs,
+    error: false,
+    disabled: true,
   },
 };
 

--- a/src/components/designsystemet/TextArea/TextArea.tsx
+++ b/src/components/designsystemet/TextArea/TextArea.tsx
@@ -19,7 +19,6 @@ export interface TextAreaProps {
   readOnly?: boolean;
   inputMode?: 'email' | 'tel' | 'search' | 'text' | 'none' | 'url' | 'numeric' | 'decimal';
   maxLength?: number;
-  rows?: number;
   size?: InputSize;
 }
 
@@ -33,10 +32,10 @@ export const TextArea = ({ size = 'full', className, ...props }: TextAreaProps) 
           subText={props.description}
           required={props.required}
           optional={props.optional}
+          readonly={props.readOnly}
           embedded
         />
       }
-      readOnly={props.readOnly}
       placeholder={props.placeholder}
       disabled={props.disabled}
       value={props.value ?? ''}
@@ -46,7 +45,6 @@ export const TextArea = ({ size = 'full', className, ...props }: TextAreaProps) 
       }}
       inputMode={props.inputMode}
       error={props.error}
-      rows={props.rows}
       multiline
       counter={props.maxLength}
     />

--- a/src/components/designsystemet/TextInput/TextInput.stories.tsx
+++ b/src/components/designsystemet/TextInput/TextInput.stories.tsx
@@ -66,3 +66,19 @@ export const WithBoolError: Story = {
     error: true,
   },
 };
+
+export const Disabled: Story = {
+  args: {
+    ...defaultArgs,
+    error: true,
+    disabled: true,
+  },
+};
+
+export const ReadOnly: Story = {
+  args: {
+    ...defaultArgs,
+    error: true,
+    readOnly: true,
+  },
+};

--- a/src/components/designsystemet/TextInput/TextInput.tsx
+++ b/src/components/designsystemet/TextInput/TextInput.tsx
@@ -1,4 +1,5 @@
 import { Textfield as DsTextField } from '@digdir/designsystemet-react';
+import { HTMLInputAutoCompleteAttribute } from 'react';
 import { InputLabel } from '~/main';
 import { InputSize, inputSizeClass } from '~/utils/input/input';
 
@@ -17,14 +18,16 @@ export interface TextInputProps {
   error?: string | boolean | null;
   disabled?: boolean;
   readOnly?: boolean;
+  loading?: boolean;
   inputMode?: 'email' | 'tel' | 'search' | 'text' | 'none' | 'url' | 'numeric' | 'decimal';
   prefix?: string;
   suffix?: string;
   type?: 'email' | 'hidden' | 'password' | 'tel' | 'text' | 'time' | 'url';
   size?: InputSize;
+  autoComplete?: HTMLInputAutoCompleteAttribute;
 }
 
-export const TextInput = ({ size = 'full', type = 'text', className, ...props }: TextInputProps) => {
+export const TextInput = ({ autoComplete, size = 'full', type = 'text', className, ...props }: TextInputProps) => {
   return (
     <DsTextField
       className={`${className} ${inputSizeClass(size)}`}
@@ -35,9 +38,10 @@ export const TextInput = ({ size = 'full', type = 'text', className, ...props }:
           required={props.required}
           optional={props.optional}
           embedded
+          readonly={props.readOnly}
         />
       }
-      readOnly={props.readOnly}
+      autoComplete={autoComplete}
       placeholder={props.placeholder}
       disabled={props.disabled}
       value={props.value ?? ''}

--- a/src/components/kystverket/InputLabel/inputLabel.module.css
+++ b/src/components/kystverket/InputLabel/inputLabel.module.css
@@ -24,3 +24,12 @@
   user-select: none;
   margin-left: 8px;
 }
+
+.readOnly {
+  margin-right: var(--spacing-2);
+  font-size: 20px !important;
+}
+
+.loading {
+  margin-right: var(--spacing-2);
+}

--- a/src/components/kystverket/InputLabel/inputLabel.tsx
+++ b/src/components/kystverket/InputLabel/inputLabel.tsx
@@ -2,6 +2,7 @@ import { ReactNode } from 'react';
 import style from './inputLabel.module.css';
 import { Body, Label } from '../Typography/typography';
 import Box from '../Box/box';
+import { Icon, Spinner } from '~/main';
 
 export interface InputLabelProps {
   optional?: boolean | string | undefined;
@@ -10,11 +11,15 @@ export interface InputLabelProps {
   subText?: ReactNode | string | null;
   children?: ReactNode;
   embedded?: boolean;
+  readonly?: boolean;
+  loading?: boolean;
 }
 
 const InputLabel = ({
   text,
   subText,
+  readonly = false,
+  loading = false,
   optional = false,
   required = false,
   embedded = false,
@@ -36,7 +41,9 @@ const InputLabel = ({
     <label>
       <Box gap={8}>
         <Box gap={0} mb={children || embedded ? 0 : 8}>
-          <Box horizontal align="start">
+          <Box horizontal align="center">
+            {readonly && !loading && <Icon material="lock" filled className={style.readOnly} />}
+            {loading && <Spinner aria-label="spinning" data-size="xs" className={style.loading} />}
             <Label inline size="md" strong>
               {text}
               {required && requiredText && (


### PR DESCRIPTION
- Oppdatert tekstinput til å ta i mot props autoComplete og loading
- Oppdatert inputLabel, lagt til loading state og readonly (lås). Siden vi bruker InputLabel i stede for å sende inn en tekststreng i textinput sin label prop blir stylingen til designsystemet sin egen readonly feil, må derfor inn i inputlabel. 
- Fjernet tel fra numberinput, endret til type ="text" (se [aksel](https://aksel.nav.no/komponenter/core/textfield) for begrunnelse) og default inputMode satt til numeric