### PR TITLE
MS-359 Endringer av Details-komponenten for bruk i Maritim Sikring

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kystverket/styrbord",
-  "version": "0.300.30",
+  "version": "0.300.31",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@kystverket/styrbord",
-      "version": "0.300.30",
+      "version": "0.300.31",
       "license": "ISC",
       "dependencies": {
         "date-fns": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kystverket/styrbord",
-  "version": "0.300.30",
+  "version": "0.300.31",
   "description": "",
   "type": "module",
   "exports": {

--- a/src/components/designsystemet/Details/Details.override.scss
+++ b/src/components/designsystemet/Details/Details.override.scss
@@ -4,8 +4,7 @@
   --dsc-details-summary-background--hover: var(--color-neutral-surface-tinted);
   --dsc-details-summary-background--open: var(--color-neutral-background-tinted);
   --dsc-details-border-color: var(--color-neutral-border-subtle);
-  border-color: var(--color-neutral-border-subtle);
-  background: var(--color-neutral-background-subtle);
+  --dsc-details-background: var(--color-neutral-background-subtle);
 }
 
 .ds-card {

--- a/src/components/designsystemet/Details/Details.tsx
+++ b/src/components/designsystemet/Details/Details.tsx
@@ -13,7 +13,7 @@ export type DetailsProps = DsDetailsProps & {
 export const Details = ({ summary, children, ...props }: DetailsProps) => {
   return (
     <DsDetails {...props}>
-      <DsDetailsSummary>{summary}</DsDetailsSummary>
+      <DsDetailsSummary suppressHydrationWarning={true}>{summary}</DsDetailsSummary>
       <DsDetailsContent>{children}</DsDetailsContent>
     </DsDetails>
   );


### PR DESCRIPTION
Prøver å ta i bruk Details-komponenten for å vise changelog for Maritim Sikring (MS-359) men har behov for et par endringer:

- Endre background og border-color til å bruke variabler, slik at de kan blir overstyrt i maritim sikring 
- Legg til suppressHydrationWarning for å forsøke å fjerne feilmelding ved lasting av side (er nødvendig, ifølge Designsystemet: "Hei, <Details> bruker ein web komponent under panseret, så den er ikkje mulig å få bort. Du må bruke suppressHydrationWarning for å unngå feilmeldingen")

# Beskrivelse

En kort beskrivelse av hvorfor endringene er gjort og hva de skal løse.

## Avsjekk

Enten huk av eller fjern linjen under som bekreftelse på at det er lest og skjønt 🙂

- [x] Dette prosjektet er åpent for offentligheten, og jeg har ikke inkludert noe som ikke tåler innsyn eller distribusjon
- [X] Jeg har lagt til JIRA-saken i tittel
- [x] Jeg har inkrementert versjonsnummeret i `package.json`, og kjørt npm i etterpå for å oppdatere `package-lock.json`
