### PR TITLE
Fiks textfield label

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kystverket/styrbord",
-  "version": "0.300.40",
+  "version": "0.300.41",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@kystverket/styrbord",
-      "version": "0.300.40",
+      "version": "0.300.41",
       "license": "ISC",
       "dependencies": {
         "date-fns": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kystverket/styrbord",
-  "version": "0.300.40",
+  "version": "0.300.41",
   "description": "",
   "type": "module",
   "exports": {

--- a/src/components/kystverket/Footer/Footer.tsx
+++ b/src/components/kystverket/Footer/Footer.tsx
@@ -62,14 +62,14 @@ export function Footer({
                 </Select.Option>
                 {contactLinks
                   ? contactLinks.map((link: LinkToSite, index: number) => (
-                    <Select.Option key={index} value={link.url} className={classes.selectOption}>
-                      {link.text}
-                    </Select.Option>
+                      <Select.Option key={index} value={link.url} className={classes.selectOption}>
+                        {link.text}
+                      </Select.Option>
                     ))
                   : defaultContactLinks.map((link: LinkToSite, index: number) => (
-                    <Select.Option key={index} value={link.url} className={classes.selectOption}>
-                      {link.text}
-                    </Select.Option>
+                      <Select.Option key={index} value={link.url} className={classes.selectOption}>
+                        {link.text}
+                      </Select.Option>
                     ))}
               </Select>
             )}

--- a/src/components/kystverket/Footer/Footer.tsx
+++ b/src/components/kystverket/Footer/Footer.tsx
@@ -62,14 +62,14 @@ export function Footer({
                 </Select.Option>
                 {contactLinks
                   ? contactLinks.map((link: LinkToSite, index: number) => (
-                      <Select.Option key={index} value={link.url} className={classes.selectOption}>
-                        {link.text}
-                      </Select.Option>
+                    <Select.Option key={index} value={link.url} className={classes.selectOption}>
+                      {link.text}
+                    </Select.Option>
                     ))
                   : defaultContactLinks.map((link: LinkToSite, index: number) => (
-                      <Select.Option key={index} value={link.url} className={classes.selectOption}>
-                        {link.text}
-                      </Select.Option>
+                    <Select.Option key={index} value={link.url} className={classes.selectOption}>
+                      {link.text}
+                    </Select.Option>
                     ))}
               </Select>
             )}

--- a/src/components/kystverket/InputLabel/inputLabel.module.css
+++ b/src/components/kystverket/InputLabel/inputLabel.module.css
@@ -19,3 +19,7 @@
   margin-left: var(--spacing-8) !important;
   display: inline;
 }
+
+.content::before {
+  content: none;
+}

--- a/src/components/kystverket/InputLabel/inputLabel.tsx
+++ b/src/components/kystverket/InputLabel/inputLabel.tsx
@@ -28,7 +28,7 @@ const InputLabel = ({
 
   if (!text && children)
     return (
-      <label>
+      <label className={style.content}>
         <div>{children}</div>
       </label>
     );
@@ -37,7 +37,7 @@ const InputLabel = ({
   const optionalText = typeof optional === 'string' ? optional : undefined;
 
   return (
-    <label>
+    <label className={style.content}>
       <Box gap={8}>
         <Box gap={0} mb={children || embedded ? 0 : 8}>
           <Box horizontal align="center">

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,4 @@
 import './css/index.scss';
-import { FileUploader } from './components/kystverket/FileUploader/FileUploader';
-import { FileUploaderContext } from './components/kystverket/FileUploader/FileUploader.context';
 
 export type { SupportedLanguage, ScreenSize } from './utils/types';
 


### PR DESCRIPTION
# Beskrivelse

Ein delvis fiks av #83 Bruker litt css-triksing til å skjula den ekstra hengelåsen på readonly-felt, men fikser ikkje problemet med at me har doble <label> i utgangspunktet

## Avsjekk

Enten huk av eller fjern linjen under som bekreftelse på at det er lest og skjønt 🙂

- [x] Dette prosjektet er åpent for offentligheten, og jeg har ikke inkludert noe som ikke tåler innsyn eller distribusjon
- [x] Jeg har inkrementert versjonsnummeret i `package.json`, og kjørt npm i etterpå for å oppdatere `package-lock.json`
