### PR TITLE
mulighet for ikon og hvit bakgrunn på tag

### DIFF
--- a/base/package.json
+++ b/base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kystverket/styrbord",
-  "version": "1.5.8",
+  "version": "1.5.9",
   "description": "",
   "type": "module",
   "repository": {

--- a/base/src/components/designsystemet/Tag/Tag.module.css
+++ b/base/src/components/designsystemet/Tag/Tag.module.css
@@ -36,4 +36,14 @@
     padding-right: var(--ds-size-4);
     height: var(--ds-size-8);
   }
+
+  .withIcon {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--ds-size-1);
+  }
+
+  .plainBackground {
+    background-color: var(--ds-color-neutral-surface-default);
+  }
 }

--- a/base/src/components/designsystemet/Tag/Tag.stories.tsx
+++ b/base/src/components/designsystemet/Tag/Tag.stories.tsx
@@ -127,3 +127,67 @@ export const RoundedWithBorders: StoryFn<typeof Tag> = ({ ...rest }) => {
     </>
   );
 };
+
+export const WithIcon: Story = {
+  args: {
+    children: 'Status',
+    icon: 'check_circle',
+  },
+};
+
+export const PlainBackground: Story = {
+  args: {
+    children: 'Status',
+    plainBackground: true,
+  },
+};
+
+export const PlainBackgroundRoundedWithIcon: Story = {
+  args: {
+    children: 'Status',
+    icon: 'check_circle',
+    plainBackground: true,
+    rounded: true,
+    'data-color': 'accent',
+  },
+};
+
+export const WithIconColors: StoryFn<typeof Tag> = ({ ...rest }) => {
+  return (
+    <>
+      {colorVariants.map((color) => (
+        <Tag key={color} icon="info" data-color={color as TagProps['data-color']} {...rest}>
+          {color}
+        </Tag>
+      ))}
+    </>
+  );
+};
+
+WithIconColors.parameters = {
+  customStyles: {
+    display: 'flex',
+    flexWrap: 'wrap',
+    gap: 'var(--ds-size-2)',
+  },
+};
+
+export const RoundedWithIconColors: StoryFn<typeof Tag> = ({ ...rest }) => {
+  return (
+    <>
+      {colorVariants.map((color) => (
+        <Tag key={color} rounded icon="info" bordered data-color={color as TagProps['data-color']} {...rest}>
+          {color}
+        </Tag>
+      ))}
+    </>
+  );
+};
+
+WithIconColors.parameters = {
+  customStyles: {
+    display: 'flex',
+    flexWrap: 'wrap',
+    gap: 'var(--ds-size-2)',
+  },
+};

--- a/base/src/components/designsystemet/Tag/Tag.stories.tsx
+++ b/base/src/components/designsystemet/Tag/Tag.stories.tsx
@@ -184,7 +184,27 @@ export const RoundedWithIconColors: StoryFn<typeof Tag> = ({ ...rest }) => {
   );
 };
 
-WithIconColors.parameters = {
+RoundedWithIconColors.parameters = {
+  customStyles: {
+    display: 'flex',
+    flexWrap: 'wrap',
+    gap: 'var(--ds-size-2)',
+  },
+};
+
+export const RoundedWithIconPlainColors: StoryFn<typeof Tag> = ({ ...rest }) => {
+  return (
+    <>
+      {colorVariants.map((color) => (
+        <Tag key={color} rounded icon="info" plainBackground data-color={color as TagProps['data-color']} {...rest}>
+          {color}
+        </Tag>
+      ))}
+    </>
+  );
+};
+
+RoundedWithIconPlainColors.parameters = {
   customStyles: {
     display: 'flex',
     flexWrap: 'wrap',

--- a/base/src/components/designsystemet/Tag/Tag.tsx
+++ b/base/src/components/designsystemet/Tag/Tag.tsx
@@ -1,20 +1,43 @@
 import { Tag as DsTag, TagProps as DsTagProps } from '@digdir/designsystemet-react';
 import classes from './Tag.module.css';
+import Icon from '~/components/kystverket/Icon/icon';
+import { IconId } from '~/components/kystverket/Icon/icon.types';
 
 export type TagProps = DsTagProps & {
   bordered?: boolean;
   rounded?: boolean;
+  icon?: IconId;
+  plainBackground?: boolean;
 };
 
-const Tag = ({ bordered = false, rounded = false, className = '', ...props }: TagProps) => {
+const Tag = ({
+  bordered = false,
+  rounded = false,
+  plainBackground = false,
+  icon,
+  children,
+  className = '',
+  ...props
+}: TagProps) => {
   const classNames = [className];
-  if (bordered) {
+  if (bordered || plainBackground) {
     classNames.push(classes.bordered);
   }
   if (rounded) {
     classNames.push(classes.rounded);
   }
-  return <DsTag className={classNames.join(' ')} {...props} />;
+  if (plainBackground) {
+    classNames.push(classes.plainBackground);
+  }
+  if (icon) {
+    classNames.push(classes.withIcon);
+  }
+  return (
+    <DsTag className={classNames.join(' ')} {...props}>
+      {icon && <Icon material={icon} size="xs" />}
+      {children}
+    </DsTag>
+  );
 };
 
 export default Tag;

--- a/package-lock.json
+++ b/package-lock.json
@@ -54,7 +54,7 @@
     },
     "base": {
       "name": "@kystverket/styrbord",
-      "version": "1.5.8",
+      "version": "1.5.9",
       "license": "ISC",
       "dependencies": {
         "@digdir/designsystemet-css": "~1.9.0",


### PR DESCRIPTION
# Beskrivelse

Lag til mulighet for å bruke ikon og ha hvit bakgrunnsfarge på tag.

<img width="822" height="344" alt="image" src="https://github.com/user-attachments/assets/7509e69f-673c-4292-9503-5c48fb59d40b" />


## Avsjekk

Enten huk av eller fjern linjen under som bekreftelse på at det er lest og skjønt 🙂

- [x] Dette prosjektet er åpent for offentligheten, og jeg har ikke inkludert noe som ikke tåler innsyn eller distribusjon
- [x] Jeg har inkrementert versjonsnummeret i `package.json`, og kjørt npm i etterpå for å oppdatere `package-lock.json`
