### PR TITLE
Legge inn oversettelser og language channger

### DIFF
--- a/base/.storybook/preview.ts
+++ b/base/.storybook/preview.ts
@@ -1,7 +1,25 @@
 import type { Preview } from '@storybook/react-vite';
 import { themes } from 'storybook/theming';
+import StyrbordDecorator from '../storybook/styrbordDecorator';
 
 import '../storybook/storybook-style.scss';
+
+export const globalTypes = {
+  locale: {
+    name: 'Locale',
+    description: 'Internationalization locale',
+    toolbar: {
+      icon: 'globe',
+      items: [
+        { value: 'nb-NO', title: 'Norsk bokmål' },
+        { value: 'nn-NO', title: 'Norsk nynorsk' },
+        { value: 'en-US', title: 'Engelsk' },
+      ],
+      showName: true,
+      dynamicTitle: true,
+    },
+  },
+};
 
 const preview: Preview = {
   parameters: {
@@ -23,6 +41,7 @@ const preview: Preview = {
   },
 
   tags: ['autodocs'],
+  decorators: [StyrbordDecorator],
 };
 
 export default preview;

--- a/base/package.json
+++ b/base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kystverket/styrbord",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "description": "",
   "type": "module",
   "repository": {

--- a/base/src/components/kystverket/Header/HeaderApps.tsx
+++ b/base/src/components/kystverket/Header/HeaderApps.tsx
@@ -39,8 +39,14 @@ export function HeaderApps({ links, applications }: HeaderAppsProps) {
   return (
     <div ref={appsButtonRef}>
       <Dropdown.TriggerContext>
-        <Button popoverTarget={id} className={classes.dropdownButton} variant="ghost" onClick={openMenu}>
-          <Box horizontal gap={16} align="center" aria-label={t('header.openApplications')}>
+        <Button
+          popoverTarget={id}
+          className={classes.dropdownButton}
+          variant="ghost"
+          onClick={openMenu}
+          aria-label={t('header.openApplicationsMenu')}
+        >
+          <Box horizontal gap={16} align="center">
             <Icon material="apps" aria-hidden />
           </Box>
         </Button>

--- a/base/src/i18n/en-US.json
+++ b/base/src/i18n/en-US.json
@@ -44,7 +44,7 @@
     }
   },
   "header": {
-    "logo-alt-text": "To the front page",
+    "alt-text": "To the front page",
     "login": "Log in",
     "logout": "Log out",
     "openApplicationsMenu": "Open applications menu",

--- a/base/src/i18n/en-US.json
+++ b/base/src/i18n/en-US.json
@@ -44,13 +44,13 @@
     }
   },
   "header": {
+    "logo-alt-text": "To the front page",
     "login": "Log in",
     "logout": "Log out",
     "openApplicationsMenu": "Open applications menu",
     "openMenu": "Open menu",
     "openProfileMenu": "Open profile menu"
   },
-  "header-alt-text": "To the front page",
   "kystverket": "Norwegian coastal administration",
   "loading": "Loading",
   "organisasjonsnummer": "Organization number",

--- a/base/src/i18n/nb-NO.json
+++ b/base/src/i18n/nb-NO.json
@@ -44,13 +44,13 @@
     }
   },
   "header": {
+    "alt-text": "Til forsiden",
     "login": "Logg inn",
     "logout": "Logg ut",
     "openApplicationsMenu": "Åpne applikasjonsmeny",
     "openMenu": "Åpne meny",
     "openProfileMenu": "Åpne profilmeny"
   },
-  "header-alt-text": "Til forsiden",
   "kystverket": "Kystverket",
   "loading": "Laster",
   "organisasjonsnummer": "Organisasjonsnummer",

--- a/base/src/i18n/nn-NO.json
+++ b/base/src/i18n/nn-NO.json
@@ -44,13 +44,13 @@
     }
   },
   "header": {
+    "alt-text": "Til framsida",
     "login": "Logg inn",
     "logout": "Logg ut",
     "openApplicationsMenu": "Opne applikasjonsmeny",
     "openMenu": "Opne meny",
     "openProfileMenu": "Opne profilmeny"
   },
-  "header-alt-text": "Til framsida",
   "kystverket": "Kystverket",
   "loading": "Lastar",
   "organisasjonsnummer": "Organisasjonsnummer",

--- a/base/storybook/styrbordDecorator.tsx
+++ b/base/storybook/styrbordDecorator.tsx
@@ -1,17 +1,21 @@
-import { PartialStoryFn } from 'storybook/internal/types';
+import { PartialStoryFn, StoryContext } from 'storybook/internal/types';
 
 import './storybook-style.scss';
 import { STYRBORD_TRANSLATIONS_NAMESPACE, StyrbordTranslations } from '~/translations';
 import { SprakProvider } from '@kystverket/sprak-react';
 
-const StyrbordDecorator = (Story: PartialStoryFn) => (
-  <div>
-    <SprakProvider locale="nb-NO" defaultNamespace={STYRBORD_TRANSLATIONS_NAMESPACE}>
-      <StyrbordTranslations>
-        <Story />
-      </StyrbordTranslations>
-    </SprakProvider>
-  </div>
-);
+const StyrbordDecorator = (Story: PartialStoryFn, context: StoryContext) => {
+  const locale = context.globals?.locale ?? 'nb-NO';
+  document.documentElement.lang = locale;
+  return (
+    <div>
+      <SprakProvider locale={locale} defaultNamespace={STYRBORD_TRANSLATIONS_NAMESPACE}>
+        <StyrbordTranslations>
+          <Story />
+        </StyrbordTranslations>
+      </SprakProvider>
+    </div>
+  );
+};
 
 export default StyrbordDecorator;

--- a/package-lock.json
+++ b/package-lock.json
@@ -54,7 +54,7 @@
     },
     "base": {
       "name": "@kystverket/styrbord",
-      "version": "1.6.1",
+      "version": "1.6.2",
       "license": "ISC",
       "dependencies": {
         "@digdir/designsystemet-css": "~1.13.3",


### PR DESCRIPTION
# Beskrivelse
- Fikse accessibility for screen readers i header
- Legge inn language changer i styrbord for å gjøre testing i flere språk lettere
<img width="614" height="190" alt="image" src="https://github.com/user-attachments/assets/e35de2b8-e635-49af-a5b1-0ca94c29886e" />



