### PR TITLE
SAK-858: Popover style oppdatering

### DIFF
--- a/base/package.json
+++ b/base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kystverket/styrbord",
-  "version": "1.6.6",
+  "version": "1.6.7",
   "description": "",
   "type": "module",
   "repository": {

--- a/base/src/components/designsystemet/Popover/Popover.override.scss
+++ b/base/src/components/designsystemet/Popover/Popover.override.scss
@@ -1,0 +1,12 @@
+@layer styrbord-modules {
+  .ds-popover {
+    border-color: var(--ds-color-border-subtle);
+    border-radius: var(--ds-border-radius-lg);
+    padding-inline: var(--ds-size-5);
+    padding-block: var(--ds-size-4);
+    box-shadow: var(--ds-shadow-lg);
+  }
+  [data-popover='inline'] {
+    text-decoration-color: var(--ds-color-main-surface-tinted);
+  }
+}

--- a/base/src/components/designsystemet/Popover/Popover.override.scss
+++ b/base/src/components/designsystemet/Popover/Popover.override.scss
@@ -6,7 +6,13 @@
     padding-block: var(--ds-size-4);
     box-shadow: var(--ds-shadow-lg);
   }
+
   [data-popover='inline'] {
-    text-decoration-color: var(--ds-color-main-surface-tinted);
+    text-decoration-color: var(--ds-color-primary-border-default);
+  }
+
+  /* Highlight the inline trigger when its popover is open */
+  :has(> .ds-popover:popover-open) [data-popover='inline'] {
+    background-color: var(--ds-color-primary-surface-tinted);
   }
 }

--- a/base/src/components/designsystemet/Popover/Popover.stories.tsx
+++ b/base/src/components/designsystemet/Popover/Popover.stories.tsx
@@ -18,6 +18,37 @@ export default {
       },
     },
   },
+  argTypes: {
+    'data-color': {
+      control: 'select',
+      options: [undefined, 'neutral', 'accent', 'danger', 'info', 'warning', 'success'],
+    },
+    'data-size': {
+      control: 'radio',
+      options: ['sm', 'md', 'lg'],
+    },
+    placement: {
+      control: 'select',
+      options: [
+        'top',
+        'top-start',
+        'top-end',
+        'bottom',
+        'bottom-start',
+        'bottom-end',
+        'left',
+        'left-start',
+        'left-end',
+        'right',
+        'right-start',
+        'right-end',
+      ],
+    },
+    variant: {
+      control: 'radio',
+      options: [undefined, 'tinted'],
+    },
+  },
   play: async (ctx) => {
     // When not in Docs mode, automatically open the popover
     const canvas = within(ctx.canvasElement);
@@ -29,21 +60,28 @@ export default {
 } satisfies Meta;
 
 export const Preview: StoryFn<typeof Popover> = (args) => {
+  const [open, setOpen] = useState(false);
+
   return (
-    <Popover.TriggerContext>
-      <Popover.Trigger>My trigger!</Popover.Trigger>
-      <Popover {...args}>popover content</Popover>
-    </Popover.TriggerContext>
+    <Box gap={8} align="start">
+      <Paragraph>
+        This popover is kept open for testing purposes. Normally, it closes when clicking outside of it.
+      </Paragraph>
+      <Popover.TriggerContext>
+        <Popover.Trigger onClick={() => setOpen((prev) => !prev)}>My trigger!</Popover.Trigger>
+        <Popover open={open} {...args}>
+          popover content
+        </Popover>
+      </Popover.TriggerContext>
+    </Box>
   );
 };
 
 Preview.args = {
   placement: 'top',
-};
-Preview.parameters = {
-  customStyles: {
-    paddingTop: '5rem',
-  },
+  'data-size': 'md',
+  'data-color': undefined,
+  variant: undefined,
 };
 
 export const Interactive: StoryFn<typeof Popover> = () => {
@@ -78,25 +116,23 @@ Interactive.parameters = {
 
 export const DottedUnderline: StoryFn<typeof Popover> = () => {
   return (
-    <>
-      <Popover.TriggerContext>
+    <Popover.TriggerContext>
+      <Paragraph>
+        Vi bruker <Popover.Trigger inline>design tokens</Popover.Trigger> for å sikre at vi har en konsistent design.
+      </Paragraph>
+      <Popover data-color="neutral">
         <Paragraph>
-          Vi bruker <Popover.Trigger inline>design tokens</Popover.Trigger> for å sikre at vi har en konsistent design.
+          <strong
+            style={{
+              display: 'block',
+            }}
+          >
+            Design tokens
+          </strong>
+          Design tokens er en samling av variabler som definerer designet i et designsystem.
         </Paragraph>
-        <Popover data-color="neutral">
-          <Paragraph>
-            <strong
-              style={{
-                display: 'block',
-              }}
-            >
-              Design tokens
-            </strong>
-            Design tokens er en samling av variabler som definerer designet i et designsystem.
-          </Paragraph>
-        </Popover>
-      </Popover.TriggerContext>
-    </>
+      </Popover>
+    </Popover.TriggerContext>
   );
 };
 DottedUnderline.parameters = {
@@ -161,18 +197,6 @@ Variants.parameters = {
     padding: '5rem 1rem',
   },
 };
-Variants.play = () => {};
-Variants.parameters = {
-  customStyles: {
-    display: 'grid',
-    gridTemplateColumns: 'repeat(4, 1fr)',
-    gap: 'var(--ds-size-2)',
-    height: '100%',
-    width: '100%',
-    placeItems: 'center',
-    padding: '5rem 3rem',
-  },
-};
 
 export const Controlled: StoryFn<typeof Popover> = () => {
   const [open, setOpen] = useState(false);
@@ -218,18 +242,6 @@ export const Sizes: StoryFn<typeof Popover> = () => {
     </Box>
   );
 };
-Sizes.play = () => {};
-Sizes.parameters = {
-  customStyles: {
-    display: 'grid',
-    gridTemplateColumns: 'repeat(3, 1fr)',
-    gap: 'var(--ds-size-2)',
-    height: '100%',
-    width: '100%',
-    placeItems: 'center',
-    padding: '5rem 3rem',
-  },
-};
 
 export const WithoutContext: StoryFn<typeof Popover> = () => {
   const [open, setOpen] = useState(false);
@@ -252,9 +264,4 @@ export const WithoutContext: StoryFn<typeof Popover> = () => {
       </Popover>
     </>
   );
-};
-WithoutContext.parameters = {
-  customStyles: {
-    padding: '8rem 6rem 1rem',
-  },
 };

--- a/base/src/components/designsystemet/Popover/Popover.stories.tsx
+++ b/base/src/components/designsystemet/Popover/Popover.stories.tsx
@@ -9,13 +9,6 @@ export default {
   component: Popover,
   tags: ['autodocs', 'ds'],
   parameters: {
-    layout: 'fullscreen',
-    customStyles: {
-      display: 'flex',
-      placeItems: 'end',
-      placeContent: 'center',
-      padding: '1rem 2rem',
-    },
     chromatic: {
       disableSnapshot: false,
     },
@@ -204,6 +197,37 @@ export const Controlled: StoryFn<typeof Popover> = () => {
 Controlled.parameters = {
   customStyles: {
     padding: '8rem 6rem 1rem',
+  },
+};
+
+export const Sizes: StoryFn<typeof Popover> = () => {
+  const [open, setOpen] = useState(false);
+
+  useEffect(() => setOpen(true), []);
+
+  return (
+    <Box gap={64} align="start" px={64}>
+      {(['sm', 'md', 'lg'] as const).map((size) => (
+        <Popover.TriggerContext key={size}>
+          <Popover.Trigger>popover</Popover.Trigger>
+          <Popover open={open} placement="top" autoPlacement={false} data-size={size}>
+            {size}
+          </Popover>
+        </Popover.TriggerContext>
+      ))}
+    </Box>
+  );
+};
+Sizes.play = () => {};
+Sizes.parameters = {
+  customStyles: {
+    display: 'grid',
+    gridTemplateColumns: 'repeat(3, 1fr)',
+    gap: 'var(--ds-size-2)',
+    height: '100%',
+    width: '100%',
+    placeItems: 'center',
+    padding: '5rem 3rem',
   },
 };
 

--- a/base/src/components/kystverket/FilePreviewer/FilePreviewer.stories.tsx
+++ b/base/src/components/kystverket/FilePreviewer/FilePreviewer.stories.tsx
@@ -2,13 +2,12 @@ import type { Meta, StoryFn } from '@storybook/react-vite';
 import { FilePreviewRef, FilePreviewerDialogProps } from './dialog/FilePreviewer-dialog';
 import StyrbordDecorator from '../../../../storybook/styrbordDecorator';
 
-import { Box, Button } from '~/main';
+import { Box, Button, FilePreviewer } from '~/main';
 import { useRef } from 'react';
 
 import atlas from '@assets/img/atlas/atlas 1.jpeg';
 import pikekyst from '@assets/documents/Pikekyst Oppskrift.pdf';
 import geojson from '@assets/documents/geojson.json';
-import { FilePreviewer } from '~/main';
 
 const defaultProps: FilePreviewerDialogProps = {
   animation: 'none',
@@ -39,13 +38,6 @@ const meta = {
   component: FilePreviewer,
   decorators: [StyrbordDecorator],
   tags: ['autodocs', 'kyv', 'beta'],
-  parameters: {
-    docs: {
-      source: {
-        type: 'code',
-      },
-    },
-  },
   args: {
     animation: 'slide',
     files: defaultProps.files,

--- a/base/src/css/index.scss
+++ b/base/src/css/index.scss
@@ -28,6 +28,7 @@
   @include meta.load-css('../components/designsystemet/Avatar/Avatar.override.scss');
   @include meta.load-css('../components/designsystemet/Dropdown/Dropdown.override.scss');
   @include meta.load-css('../components/kystverket/Datepicker/Datepicker.override.scss');
+  @include meta.load-css('../components/designsystemet/Popover/Popover.override.scss');
 }
 
 // Override popover max-width fra 300px til 400px for LinkEditor brukstilfelle

--- a/package-lock.json
+++ b/package-lock.json
@@ -54,7 +54,7 @@
     },
     "base": {
       "name": "@kystverket/styrbord",
-      "version": "1.6.6",
+      "version": "1.6.7",
       "license": "ISC",
       "dependencies": {
         "@digdir/designsystemet-css": "~1.13.3",


### PR DESCRIPTION
# Beskrivelse
Oppdaterer style for Popover

> Border-color er satt til border-subtle på alle varianter
> Border-radius er satt til lg (4px) på alle varianter
> Padding er økt til å bedre matche dropdown komponent
> Left/right padding → size-token 5
> Top/bottom padding → size-token 4
> Box-shadow er satt til lg
> Active state på “dotted underline” har bakgrunnsfarge color/main/surface-tinted

