### PR TITLE
Forbedre bildeopplastning i rich text area og markdown to react

### DIFF
--- a/base/package.json
+++ b/base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kystverket/styrbord",
-  "version": "1.8.2",
+  "version": "1.8.3",
   "description": "",
   "type": "module",
   "repository": {

--- a/base/src/components/kystverket/MarkdownToReact/markdownToReact.module.css
+++ b/base/src/components/kystverket/MarkdownToReact/markdownToReact.module.css
@@ -21,6 +21,15 @@
   margin-top: 0.25rem;
 }
 
+.markdownToReact img {
+  display: block;
+  max-inline-size: min(100%, 32rem);
+  max-block-size: min(100%, 12rem);
+  inline-size: auto;
+  block-size: auto;
+  margin: 0.5rem 0;
+}
+
 .heading1 {
   font-size: var(--ds-font-size-5);
   font-weight: var(--ds-font-weight-medium);

--- a/base/src/components/kystverket/MarkdownToReact/markdownToReact.module.css
+++ b/base/src/components/kystverket/MarkdownToReact/markdownToReact.module.css
@@ -24,7 +24,6 @@
 .markdownToReact img {
   display: block;
   max-inline-size: min(100%, 32rem);
-  max-block-size: min(100%, 12rem);
   inline-size: auto;
   block-size: auto;
   margin: 0.5rem 0;

--- a/base/src/components/kystverket/MarkdownToReact/markdownToReact.stories.tsx
+++ b/base/src/components/kystverket/MarkdownToReact/markdownToReact.stories.tsx
@@ -3,6 +3,8 @@ import MarkdownToReact from './markdownToReact';
 import StyrbordDecorator from '../../../../storybook/styrbordDecorator';
 import { ResolvedImageRef } from '~/components/kystverket/MarkdownToReact/markdownToReact';
 
+import atlas from '@assets/img/atlas/atlas 1.jpeg';
+
 const meta = {
   title: 'Components/MarkdownToReact',
   component: MarkdownToReact,
@@ -119,7 +121,7 @@ export const ResolveImageRefExample: Story = {
     resolveImageRef: (ref: string) => {
       const imageRefMap: Record<string, ResolvedImageRef> = {
         'image://86062b3c-ebc8-48d0-9d08-8c282f5d8c69': {
-          src: '/assets/img/atlas/atlas%201.jpeg',
+          src: atlas,
         },
       };
 

--- a/base/src/components/kystverket/RichTextArea/hooks/useRichTextImageUpload.ts
+++ b/base/src/components/kystverket/RichTextArea/hooks/useRichTextImageUpload.ts
@@ -46,7 +46,6 @@ const normalizeUploadResult = (
     src: result.src,
     ref: result.ref,
     alt: result.alt ?? file.name.replace(/\.[^.]+$/, ''),
-    title: result.title,
   };
 };
 
@@ -102,7 +101,7 @@ export const useRichTextImageUpload = ({
         sasToRefMap.current.set(uploadedImage.src, uploadedImage.ref);
       }
 
-      insertImageNode({ src: uploadedImage.src, alt: uploadedImage.alt, title: uploadedImage.title });
+      insertImageNode({ src: uploadedImage.src, alt: uploadedImage.alt });
       return true;
     } catch {
       return false;

--- a/base/src/components/kystverket/RichTextArea/richTextArea.module.css
+++ b/base/src/components/kystverket/RichTextArea/richTextArea.module.css
@@ -84,6 +84,10 @@
 }
 
 .editor :global(.ProseMirror .milkdown-image-inline img) {
+  display: block;
+  max-inline-size: min(100%, 32rem);
+  inline-size: auto;
+  block-size: auto;
   outline: 2px solid transparent;
   outline-offset: 2px;
   border-radius: var(--ds-border-radius-sm);

--- a/base/src/components/kystverket/RichTextArea/richTextArea.stories.tsx
+++ b/base/src/components/kystverket/RichTextArea/richTextArea.stories.tsx
@@ -108,7 +108,7 @@ export const WithImageRef: Story = {
 
       return imageRefMap[ref]?.src;
     },
-    onUpload: async (file) => {
+    onImageUpload: async (file) => {
       const src = await fileToDataUrl(file);
       // Simulate a stable blob reference that would be generated server-side
       const ref = `image://${crypto.randomUUID()}`;

--- a/base/src/components/kystverket/RichTextArea/richTextArea.stories.tsx
+++ b/base/src/components/kystverket/RichTextArea/richTextArea.stories.tsx
@@ -4,6 +4,8 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import StyrbordDecorator from '../../../../storybook/styrbordDecorator';
 import { RichTextArea, RichTextAreaProps } from './richTextArea';
 
+import atlas from '@assets/img/atlas/atlas 1.jpeg';
+
 const meta = {
   title: 'Form/RichTextArea/RichTextArea',
   component: RichTextArea,
@@ -93,9 +95,19 @@ export const WithError: Story = {
 export const WithImageRef: Story = {
   args: {
     ...defaultArgs,
+
+    value: '![bilde.png](image://86062b3c-ebc8-48d0-9d08-8c282f5d8c69)',
     label: 'Rikt tekstfelt med bildereferanse',
     description: 'Last opp et bilde — markdownutdata vil inneholde en stabil referanse til bildet,.',
+    resolveImageRef: (ref: string) => {
+      const imageRefMap: Record<string, { src: string }> = {
+        'image://86062b3c-ebc8-48d0-9d08-8c282f5d8c69': {
+          src: atlas,
+        },
+      };
 
+      return imageRefMap[ref]?.src;
+    },
     onUpload: async (file) => {
       const src = await fileToDataUrl(file);
       // Simulate a stable blob reference that would be generated server-side

--- a/base/src/components/kystverket/RichTextArea/richTextArea.tsx
+++ b/base/src/components/kystverket/RichTextArea/richTextArea.tsx
@@ -44,7 +44,7 @@ export type { RichTextAreaProps };
 const RichTextAreaContainer = ({
   value,
   onChange,
-  onUpload,
+  onImageUpload: onUpload,
   resolveImageRef,
   placeholder,
   disabled = false,

--- a/base/src/components/kystverket/RichTextArea/richTextArea.tsx
+++ b/base/src/components/kystverket/RichTextArea/richTextArea.tsx
@@ -67,6 +67,7 @@ const RichTextAreaContainer = ({
   const latestOnChangeRef = useRef(onChange);
   const latestOnUploadRef = useRef(onUpload);
   const lastKnownMarkdownRef = useRef(normalizedValue);
+  const lastSyncedEditorMarkdownRef = useRef(editorMarkdown);
   const imageInputRef = useRef<HTMLInputElement | null>(null);
 
   latestOnChangeRef.current = onChange;
@@ -156,7 +157,7 @@ const RichTextAreaContainer = ({
       return;
     }
 
-    if (normalizedValue === lastKnownMarkdownRef.current) {
+    if (normalizedValue === lastKnownMarkdownRef.current && editorMarkdown === lastSyncedEditorMarkdownRef.current) {
       return;
     }
 
@@ -171,6 +172,7 @@ const RichTextAreaContainer = ({
     }
 
     lastKnownMarkdownRef.current = normalizedValue;
+    lastSyncedEditorMarkdownRef.current = editorMarkdown;
     editor.action(replaceAll(editorMarkdown));
   }, [editorMarkdown, get, normalizedValue]);
 

--- a/base/src/components/kystverket/RichTextArea/richTextArea.tsx
+++ b/base/src/components/kystverket/RichTextArea/richTextArea.tsx
@@ -15,7 +15,6 @@ import classes from './richTextArea.module.css';
 import { Fieldset, LabelContent, ValidationMessage } from '~/main';
 import LinkEditor from './components/LinkEditor/linkEditor';
 import { Toolbar } from './components/Toolbar/toolbar';
-import { replaceUrlsWithRefs } from './utils/linkUtils';
 import { useRichTextToolbarState } from './hooks/useRichTextToolbarState';
 import { useRichTextLinkEditor } from './hooks/useRichTextLinkEditor';
 import { useRichTextImageUpload } from './hooks/useRichTextImageUpload';
@@ -36,12 +35,17 @@ import {
   createRichTextAreaEditorDrop,
 } from './richTextArea.editor';
 import type { ImageInsertHandler, RichTextAreaProps } from './richTextArea.types';
+import {
+  convertFromRefToImage,
+  replaceImageUrlsWithRefs,
+} from '~/components/kystverket/RichTextArea/utils/ImageRefUtils';
 export type { RichTextAreaProps };
 
 const RichTextAreaContainer = ({
   value,
   onChange,
   onUpload,
+  resolveImageRef,
   placeholder,
   disabled = false,
   label,
@@ -53,7 +57,13 @@ const RichTextAreaContainer = ({
   const [internalError, setInternalError] = useState<string | undefined>(undefined);
   const displayedError = externalError ?? internalError;
 
+  // Owned here so useEditor config can close over them before useRichTextImageUpload is called.
+  const sasToRefMap = useRef(new Map<string, string>());
+
   const normalizedValue = normalizeMarkdownBreakTags(value ?? '');
+  const editorMarkdown = resolveImageRef
+    ? convertFromRefToImage(normalizedValue, resolveImageRef, sasToRefMap.current)
+    : normalizedValue;
   const latestOnChangeRef = useRef(onChange);
   const latestOnUploadRef = useRef(onUpload);
   const lastKnownMarkdownRef = useRef(normalizedValue);
@@ -62,8 +72,6 @@ const RichTextAreaContainer = ({
   latestOnChangeRef.current = onChange;
   latestOnUploadRef.current = onUpload;
 
-  // Owned here so useEditor config can close over them before useRichTextImageUpload is called.
-  const sasToRefMap = useRef(new Map<string, string>());
   const insertImageFromFileRef = useRef<ImageInsertHandler>(() => {});
   const inlineImageConfigUpdaterRef = useRef<(config: InlineImageConfig) => InlineImageConfig>((c) => c);
 
@@ -80,7 +88,7 @@ const RichTextAreaContainer = ({
       Editor.make()
         .config((ctx) => {
           ctx.set(rootCtx, root);
-          ctx.set(defaultValueCtx, normalizedValue);
+          ctx.set(defaultValueCtx, editorMarkdown);
           ctx.update(inlineImageConfig.key, updateInlineImageConfig);
           ctx.update(editorViewOptionsCtx, (prev = {}) => ({
             ...prev,
@@ -95,7 +103,7 @@ const RichTextAreaContainer = ({
           }));
           ctx.get(listenerCtx).markdownUpdated((_ctx, markdown) => {
             const normalizedMarkdown = normalizeMarkdownBreakTags(markdown);
-            const transformedMarkdown = replaceUrlsWithRefs(normalizedMarkdown, sasToRefMap.current);
+            const transformedMarkdown = replaceImageUrlsWithRefs(normalizedMarkdown, sasToRefMap.current);
 
             if (transformedMarkdown === lastKnownMarkdownRef.current) {
               updateToolbarState(_ctx);
@@ -163,8 +171,8 @@ const RichTextAreaContainer = ({
     }
 
     lastKnownMarkdownRef.current = normalizedValue;
-    editor.action(replaceAll(normalizedValue));
-  }, [get, normalizedValue]);
+    editor.action(replaceAll(editorMarkdown));
+  }, [editorMarkdown, get, normalizedValue]);
 
   // Sett knappestatus når editoren er tilgjengelig.
   useEffect(() => {

--- a/base/src/components/kystverket/RichTextArea/richTextArea.types.ts
+++ b/base/src/components/kystverket/RichTextArea/richTextArea.types.ts
@@ -2,17 +2,7 @@ import type { CmdKey } from '@milkdown/core';
 
 // resolveImageRef?: (ref: string) => ResolvedImageRef;
 
-type ImageHandlersBoth = {
-  onUpload: UploadImageFn;
-  resolveImageRef: (ref: string) => string | null;
-};
-
-type ImageHandlersNeither = {
-  onUpload?: never;
-  resolveImageRef?: never;
-};
-
-type RichTextAreaBaseProps = {
+export type RichTextAreaProps = {
   value: string | null | undefined;
   onChange: (markdown: string) => void;
   placeholder?: string;
@@ -23,15 +13,16 @@ type RichTextAreaBaseProps = {
   optional?: boolean | string;
   required?: boolean | string;
   error?: string;
+  /** For when image is uploaded, to give it a ref*/
+  onImageUpload?: UploadImageFn;
+  resolveImageRef?: (ref: string) => string | null;
 };
-
-export type RichTextAreaProps = RichTextAreaBaseProps & (ImageHandlersBoth | ImageHandlersNeither);
 
 export type ToolbarCommand<T = unknown> = { key: CmdKey<T>; value?: T };
 
-export type ImageMarkdown = { src: string; alt?: string; title?: string };
+export type ImageMarkdown = { src: string; alt?: string };
 
-export type ImageUploadResult = { src: string; ref?: string; alt?: string; title?: string };
+export type ImageUploadResult = { src: string; ref?: string; alt?: string };
 
 export type ImageInsertHandler = (file: File) => void;
 

--- a/base/src/components/kystverket/RichTextArea/richTextArea.types.ts
+++ b/base/src/components/kystverket/RichTextArea/richTextArea.types.ts
@@ -11,9 +11,9 @@ export type RichTextAreaProps = {
   optional?: boolean | string;
   required?: boolean | string;
   error?: string;
-  /** For when image is uploaded, to give it a ref*/
+  /** For when image is uploaded, to give it a ref */
   onImageUpload?: UploadImageFn;
-  resolveImageRef?: (ref: string) => string | null;
+  resolveImageRef?: (ref: string) => string | null | undefined;
 };
 
 export type ToolbarCommand<T = unknown> = { key: CmdKey<T>; value?: T };

--- a/base/src/components/kystverket/RichTextArea/richTextArea.types.ts
+++ b/base/src/components/kystverket/RichTextArea/richTextArea.types.ts
@@ -1,9 +1,20 @@
 import type { CmdKey } from '@milkdown/core';
 
-export type RichTextAreaProps = {
+// resolveImageRef?: (ref: string) => ResolvedImageRef;
+
+type ImageHandlersBoth = {
+  onUpload: UploadImageFn;
+  resolveImageRef: (ref: string) => string | null;
+};
+
+type ImageHandlersNeither = {
+  onUpload?: never;
+  resolveImageRef?: never;
+};
+
+type RichTextAreaBaseProps = {
   value: string | null | undefined;
   onChange: (markdown: string) => void;
-  onUpload?: UploadImageFn;
   placeholder?: string;
   disabled?: boolean;
   className?: string;
@@ -13,6 +24,8 @@ export type RichTextAreaProps = {
   required?: boolean | string;
   error?: string;
 };
+
+export type RichTextAreaProps = RichTextAreaBaseProps & (ImageHandlersBoth | ImageHandlersNeither);
 
 export type ToolbarCommand<T = unknown> = { key: CmdKey<T>; value?: T };
 

--- a/base/src/components/kystverket/RichTextArea/richTextArea.types.ts
+++ b/base/src/components/kystverket/RichTextArea/richTextArea.types.ts
@@ -1,7 +1,5 @@
 import type { CmdKey } from '@milkdown/core';
 
-// resolveImageRef?: (ref: string) => ResolvedImageRef;
-
 export type RichTextAreaProps = {
   value: string | null | undefined;
   onChange: (markdown: string) => void;

--- a/base/src/components/kystverket/RichTextArea/utils/ImageRefUtils.ts
+++ b/base/src/components/kystverket/RichTextArea/utils/ImageRefUtils.ts
@@ -54,8 +54,9 @@ export const convertFromRefToImage = (
  * @returns
  */
 export const replaceImageUrlsWithRefs = (markdown: string, sasToRefMap: Map<string, string>): string =>
-  markdown.replace(/!\[([^\]]*)\]\(([^)\s]+)\)/g, (match, altText: string, url: string) => {
+  markdown.replace(/!\[([^\]]*)\]\(([^)\s]+)(?:\s+"([^"]*)")?\)/g, (match, altText: string, url: string, title: string | undefined) => {
     const ref = sasToRefMap.get(url);
     if (!ref) return match;
-    return `![${altText}](${ref})`;
+    const titlePart = title ? ` "${title}"` : '';
+    return `![${altText}](${ref}${titlePart})`;
   });

--- a/base/src/components/kystverket/RichTextArea/utils/ImageRefUtils.ts
+++ b/base/src/components/kystverket/RichTextArea/utils/ImageRefUtils.ts
@@ -1,28 +1,5 @@
 type ResolvedImageRef = { src: string; alt?: string } | string | null | undefined;
 
-/**
- *
- * @param markdown
- * @param resolveImageRef
- * @returns
- */
-export const replaceRefsWithImageUrls = (markdown: string, resolveImageRef: (ref: string) => ResolvedImageRef) => {
-  const imageRegex = /!\[([^\]]*)\]\(([^)\s]+)\)/g;
-
-  return markdown.replace(imageRegex, (fullMatch, alt: string, src: string) => {
-    const resolvedImageRef = resolveImageRef(src);
-
-    if (resolvedImageRef === undefined || resolvedImageRef === null) return fullMatch;
-
-    const resolvedSrc = typeof resolvedImageRef === 'string' ? resolvedImageRef : resolvedImageRef.src;
-    const resolvedAlt = typeof resolvedImageRef === 'string' ? alt : (resolvedImageRef.alt ?? alt);
-
-    return `![${resolvedAlt}](${resolvedSrc})`;
-  });
-};
-
-export type ImageUploadResult = { src: string; ref?: string; alt?: string };
-
 export const convertFromRefToImage = (
   markdown: string,
   resolveImageRef: (ref: string) => ResolvedImageRef,
@@ -47,16 +24,13 @@ export const convertFromRefToImage = (
   });
 };
 
-/**
- *
- * @param markdown
- * @param sasToRefMap
- * @returns
- */
 export const replaceImageUrlsWithRefs = (markdown: string, sasToRefMap: Map<string, string>): string =>
-  markdown.replace(/!\[([^\]]*)\]\(([^)\s]+)(?:\s+"([^"]*)")?\)/g, (match, altText: string, url: string, title: string | undefined) => {
-    const ref = sasToRefMap.get(url);
-    if (!ref) return match;
-    const titlePart = title ? ` "${title}"` : '';
-    return `![${altText}](${ref}${titlePart})`;
-  });
+  markdown.replace(
+    /!\[([^\]]*)\]\(([^)\s]+)(?:\s+"([^"]*)")?\)/g,
+    (match, altText: string, url: string, title: string | undefined) => {
+      const ref = sasToRefMap.get(url);
+      if (!ref) return match;
+      const titlePart = title ? ` "${title}"` : '';
+      return `![${altText}](${ref}${titlePart})`;
+    },
+  );

--- a/base/src/components/kystverket/RichTextArea/utils/ImageRefUtils.ts
+++ b/base/src/components/kystverket/RichTextArea/utils/ImageRefUtils.ts
@@ -1,0 +1,60 @@
+type ResolvedImageRef = { src: string; alt?: string } | string | null | undefined;
+
+/**
+ *
+ * @param markdown
+ * @param resolveImageRef
+ * @returns
+ */
+export const replaceRefsWithImageUrls = (markdown: string, resolveImageRef: (ref: string) => ResolvedImageRef) => {
+  const imageRegex = /!\[([^\]]*)\]\(([^)\s]+)\)/g;
+
+  return markdown.replace(imageRegex, (fullMatch, alt: string, src: string) => {
+    const resolvedImageRef = resolveImageRef(src);
+
+    if (resolvedImageRef === undefined || resolvedImageRef === null) return fullMatch;
+
+    const resolvedSrc = typeof resolvedImageRef === 'string' ? resolvedImageRef : resolvedImageRef.src;
+    const resolvedAlt = typeof resolvedImageRef === 'string' ? alt : (resolvedImageRef.alt ?? alt);
+
+    return `![${resolvedAlt}](${resolvedSrc})`;
+  });
+};
+
+export type ImageUploadResult = { src: string; ref?: string; alt?: string };
+
+export const convertFromRefToImage = (
+  markdown: string,
+  resolveImageRef: (ref: string) => ResolvedImageRef,
+  urlToRefMap?: Map<string, string>,
+) => {
+  const imageRegex = /!\[([^\]]*)\]\(([^)\s]+)\)/g;
+
+  return markdown.replace(imageRegex, (fullMatch, alt: string, ref: string) => {
+    const resolvedImageRef = resolveImageRef(ref);
+
+    if (resolvedImageRef === undefined || resolvedImageRef === null) {
+      return fullMatch;
+    }
+
+    const resolvedSrc = typeof resolvedImageRef === 'string' ? resolvedImageRef : resolvedImageRef.src;
+    const resolvedAlt = typeof resolvedImageRef === 'string' ? alt : (resolvedImageRef.alt ?? alt);
+
+    urlToRefMap?.set(resolvedSrc, ref);
+
+    return `![${resolvedAlt}](${resolvedSrc})`;
+  });
+};
+
+/**
+ *
+ * @param markdown
+ * @param sasToRefMap
+ * @returns
+ */
+export const replaceImageUrlsWithRefs = (markdown: string, sasToRefMap: Map<string, string>): string =>
+  markdown.replace(/!\[([^\]]*)\]\(([^)\s]+)\)/g, (match, altText: string, url: string) => {
+    const ref = sasToRefMap.get(url);
+    if (!ref) return match;
+    return `![${altText}](${ref})`;
+  });

--- a/base/src/components/kystverket/RichTextArea/utils/ImageRefUtils.ts
+++ b/base/src/components/kystverket/RichTextArea/utils/ImageRefUtils.ts
@@ -28,9 +28,9 @@ export const convertFromRefToImage = (
   resolveImageRef: (ref: string) => ResolvedImageRef,
   urlToRefMap?: Map<string, string>,
 ) => {
-  const imageRegex = /!\[([^\]]*)\]\(([^)\s]+)\)/g;
+  const imageRegex = /!\[([^\]]*)\]\(([^)\s]+)(?:\s+"([^"]*)")?\)/g;
 
-  return markdown.replace(imageRegex, (fullMatch, alt: string, ref: string) => {
+  return markdown.replace(imageRegex, (fullMatch, alt: string, ref: string, title: string | undefined) => {
     const resolvedImageRef = resolveImageRef(ref);
 
     if (resolvedImageRef === undefined || resolvedImageRef === null) {
@@ -39,10 +39,11 @@ export const convertFromRefToImage = (
 
     const resolvedSrc = typeof resolvedImageRef === 'string' ? resolvedImageRef : resolvedImageRef.src;
     const resolvedAlt = typeof resolvedImageRef === 'string' ? alt : (resolvedImageRef.alt ?? alt);
+    const titlePart = title ? ` "${title}"` : '';
 
     urlToRefMap?.set(resolvedSrc, ref);
 
-    return `![${resolvedAlt}](${resolvedSrc})`;
+    return `![${resolvedAlt}](${resolvedSrc}${titlePart})`;
   });
 };
 

--- a/base/src/components/kystverket/RichTextArea/utils/linkUtils.ts
+++ b/base/src/components/kystverket/RichTextArea/utils/linkUtils.ts
@@ -14,25 +14,6 @@ export const normalizeHref = (rawHref: string) => {
   return `https://${href}`;
 };
 
-export const replaceUrlsWithRefs = (markdown: string, sasToRefMap: Map<string, string>): string => {
-  if (sasToRefMap.size === 0) {
-    return markdown;
-  }
-
-  // Match image syntax: ![alt](url) or ![alt](url "title")
-  // URL lookup is a plain Map.get — no regex created from the URL itself
-  return markdown.replace(
-    /!\[([^\]]*)\]\(([^)\s]+)(?:\s+"([^"]*)")?\)/g,
-    (match, alt: string, url: string, title: string | undefined) => {
-      const ref = sasToRefMap.get(url);
-      if (!ref) {
-        return match;
-      }
-      return title ? `![${alt}](${ref} "${title}")` : `![${alt}](${ref})`;
-    },
-  );
-};
-
 export const getSelectionLinkRange = (state: EditorState) => {
   const { from, to, empty, $from } = state.selection;
   const linkMarkType = state.schema.marks.link;

--- a/package-lock.json
+++ b/package-lock.json
@@ -54,7 +54,7 @@
     },
     "base": {
       "name": "@kystverket/styrbord",
-      "version": "1.8.2",
+      "version": "1.8.3",
       "license": "ISC",
       "dependencies": {
         "@digdir/designsystemet-css": "~1.15.0",


### PR DESCRIPTION
# Beskrivelse
- Endret RichTextArea slik at bilder kan håndteres toveis i stedet for kun en vei.
Dette gjør at `ref` kan parses korrekt i eksempler når brukeren er i edit-modus.
- Fjernet title prop da det var forvirrende opp i mot alt prop.
- Endret navn på `OnUpload` i RichTextArea til `OnImageUpload` for å gjøre intent mer synlig
- Lagt inn max-width på bilder, in case siden/bildet er veldig bredt