### PR TITLE
Improve Image handling in RichTextArea and MarkdownToReact

### DIFF
--- a/base/package.json
+++ b/base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kystverket/styrbord",
-  "version": "1.8.3",
+  "version": "1.8.4",
   "description": "",
   "type": "module",
   "repository": {

--- a/base/src/components/kystverket/MarkdownToReact/markdownToReact.stories.tsx
+++ b/base/src/components/kystverket/MarkdownToReact/markdownToReact.stories.tsx
@@ -108,6 +108,7 @@ const App = () => (
 };
 
 export const ResolveImageRefExample: Story = {
+  parameters: { docs: { source: { type: 'code' } } },
   args: {
     markdown: `
 # Noe kul markdown
@@ -118,14 +119,14 @@ export const ResolveImageRefExample: Story = {
 ## og et bilde som resolver!
 ![Atlas.png](image://86062b3c-ebc8-48d0-9d08-8c282f5d8c69)
 `,
-    resolveImageRef: (ref: string) => {
+    resolveImageRefs: () => {
       const imageRefMap: Record<string, ResolvedImageRef> = {
         'image://86062b3c-ebc8-48d0-9d08-8c282f5d8c69': {
           src: atlas,
         },
       };
 
-      return imageRefMap[ref];
+      return imageRefMap;
     },
   },
 };

--- a/base/src/components/kystverket/MarkdownToReact/markdownToReact.tsx
+++ b/base/src/components/kystverket/MarkdownToReact/markdownToReact.tsx
@@ -1,21 +1,30 @@
+import { useEffect, useMemo, useState } from 'react';
 import ReactMarkdown from 'react-markdown';
 import styles from './markdownToReact.module.css';
 import { Link, Paragraph } from '~/main';
+import { MaybePromise } from '~/utils/utility.types';
+
+type ResolvedImageRefs = Record<string, ResolvedImageRef>;
 
 export type MarkdownToReactProps = {
   markdown: string;
-  resolveImageRef?: (ref: string) => ResolvedImageRef;
+  /** Optional sync/async resolver that receives all refs found in markdown. */
+
+  resolveImageRefs?: (refs?: string[]) => MaybePromise<ResolvedImageRefs>;
 };
 
-export type ResolvedImageRef = { src: string; alt?: string } | undefined;
+export type ResolvedImageRef = { src: string; alt?: string } | string | null | undefined;
 
-const replaceResolvedImageRefs = (markdown: string, resolveImageRef: (ref: string) => ResolvedImageRef) => {
-  const imageRegex = /!\[([^\]]*)\]\(([^)\s]+)(?:\s+"([^"]*)")?\)/g;
+const imageRegex = /!\[([^\]]*)\]\(([^)\s]+)(?:\s+"([^"]*)")?\)/g;
 
+const getUniqueImageRefs = (markdown: string): string[] =>
+  Array.from(new Set(Array.from(markdown.matchAll(imageRegex), ([, , src]) => src)));
+
+const replaceResolvedImageRefs = (markdown: string, resolvedImageRefs: ResolvedImageRefs) => {
   return markdown.replace(imageRegex, (fullMatch, alt: string, src: string, title: string | undefined) => {
-    const resolvedImageRef = resolveImageRef(src);
+    const resolvedImageRef = resolvedImageRefs[src];
 
-    if (resolvedImageRef === undefined) return fullMatch;
+    if (resolvedImageRef === undefined || resolvedImageRef === null) return fullMatch;
 
     const resolvedSrc = typeof resolvedImageRef === 'string' ? resolvedImageRef : resolvedImageRef.src;
     const resolvedAlt = typeof resolvedImageRef === 'string' ? alt : (resolvedImageRef.alt ?? alt);
@@ -26,12 +35,24 @@ const replaceResolvedImageRefs = (markdown: string, resolveImageRef: (ref: strin
 };
 
 // Overskrifter (h1-h6) rendres som <Paragraph> med tanke på dokumenthierarki (enn så lenge, dette må vi komme tilbake til etter hvert)
-const MarkdownToReact = ({ markdown, resolveImageRef }: MarkdownToReactProps) => {
-  let renderedMarkdown = markdown.replaceAll(/\n{3,}/g, '\n\n\u00A0\n\n');
+const MarkdownToReact = ({ markdown, resolveImageRefs }: MarkdownToReactProps) => {
+  const normalizedMarkdown = useMemo(() => markdown.replaceAll(/\n{3,}/g, '\n\n\u00A0\n\n'), [markdown]);
+  const [renderedMarkdown, setRenderedMarkdown] = useState(normalizedMarkdown);
 
-  if (typeof resolveImageRef === 'function') {
-    renderedMarkdown = replaceResolvedImageRefs(renderedMarkdown, resolveImageRef);
-  }
+  useEffect(() => {
+    const uniqueRefs = getUniqueImageRefs(normalizedMarkdown);
+
+    if (!resolveImageRefs || uniqueRefs.length === 0) {
+      setRenderedMarkdown(normalizedMarkdown);
+      return;
+    }
+
+    const resolve = async () => {
+      const resolvedImageRefs = await resolveImageRefs(uniqueRefs);
+      setRenderedMarkdown(replaceResolvedImageRefs(normalizedMarkdown, resolvedImageRefs));
+    };
+    resolve();
+  }, [normalizedMarkdown, resolveImageRefs]);
 
   return (
     <div className={styles.markdownToReact}>

--- a/base/src/components/kystverket/MarkdownToReact/markdownToReact.tsx
+++ b/base/src/components/kystverket/MarkdownToReact/markdownToReact.tsx
@@ -41,6 +41,7 @@ const MarkdownToReact = ({ markdown, resolveImageRefs }: MarkdownToReactProps) =
 
   useEffect(() => {
     const uniqueRefs = getUniqueImageRefs(normalizedMarkdown);
+    let isCancelled = false;
 
     if (!resolveImageRefs || uniqueRefs.length === 0) {
       setRenderedMarkdown(normalizedMarkdown);
@@ -48,10 +49,28 @@ const MarkdownToReact = ({ markdown, resolveImageRefs }: MarkdownToReactProps) =
     }
 
     const resolve = async () => {
-      const resolvedImageRefs = await resolveImageRefs(uniqueRefs);
-      setRenderedMarkdown(replaceResolvedImageRefs(normalizedMarkdown, resolvedImageRefs));
+      try {
+        const resolvedImageRefs = await resolveImageRefs(uniqueRefs);
+
+        if (isCancelled) {
+          return;
+        }
+
+        setRenderedMarkdown(replaceResolvedImageRefs(normalizedMarkdown, resolvedImageRefs));
+      } catch {
+        if (isCancelled) {
+          return;
+        }
+
+        setRenderedMarkdown(normalizedMarkdown);
+      }
     };
-    resolve();
+
+    void resolve();
+
+    return () => {
+      isCancelled = true;
+    };
   }, [normalizedMarkdown, resolveImageRefs]);
 
   return (

--- a/base/src/components/kystverket/RichTextArea/hooks/useRichTextImagePicker.ts
+++ b/base/src/components/kystverket/RichTextArea/hooks/useRichTextImagePicker.ts
@@ -1,0 +1,63 @@
+import { useRef, useState } from 'react';
+import { editorViewCtx } from '@milkdown/core';
+import type { Editor } from '@milkdown/core';
+
+type UseRichTextImagePickerParams = {
+  disabled: boolean;
+  loading: boolean;
+  canUploadImage: boolean;
+  isUploadingImage: boolean;
+  get: () => Editor | undefined;
+  pendingImageSelectionRef: React.RefObject<{ from: number; to: number } | null>;
+  onImageFileInputChange: (event: React.ChangeEvent<HTMLInputElement>) => Promise<{ success: boolean }>;
+};
+
+type UseRichTextImagePickerReturn = {
+  imageInputRef: React.RefObject<HTMLInputElement | null>;
+  imageUploadError: string | undefined;
+  openImageFilePicker: () => void;
+  handleImageFileInputChange: (event: React.ChangeEvent<HTMLInputElement>) => Promise<void>;
+};
+
+export const useRichTextImagePicker = ({
+  disabled,
+  loading,
+  canUploadImage,
+  isUploadingImage,
+  get,
+  pendingImageSelectionRef,
+  onImageFileInputChange,
+}: UseRichTextImagePickerParams): UseRichTextImagePickerReturn => {
+  const [imageUploadError, setImageUploadError] = useState<string | undefined>(undefined);
+  const imageInputRef = useRef<HTMLInputElement | null>(null);
+
+  const openImageFilePicker = () => {
+    if (disabled || loading || !canUploadImage || isUploadingImage) {
+      return;
+    }
+
+    const editor = get();
+
+    if (editor) {
+      editor.action((ctx) => {
+        const { from, to } = ctx.get(editorViewCtx).state.selection;
+        pendingImageSelectionRef.current = { from, to };
+      });
+    }
+
+    imageInputRef.current?.click();
+  };
+
+  const handleImageFileInputChange = async (event: React.ChangeEvent<HTMLInputElement>) => {
+    setImageUploadError(undefined);
+    const { success } = await onImageFileInputChange(event);
+    setImageUploadError(success ? undefined : 'Image failed to upload');
+  };
+
+  return {
+    imageInputRef,
+    imageUploadError,
+    openImageFilePicker,
+    handleImageFileInputChange,
+  };
+};

--- a/base/src/components/kystverket/RichTextArea/hooks/useRichTextImageUpload.ts
+++ b/base/src/components/kystverket/RichTextArea/hooks/useRichTextImageUpload.ts
@@ -1,9 +1,10 @@
 import { useState } from 'react';
-import { commandsCtx } from '@milkdown/core';
+import { commandsCtx, editorViewCtx } from '@milkdown/core';
 import type { Editor } from '@milkdown/core';
 import { insertImageCommand } from '@milkdown/preset-commonmark';
 import type { Ctx } from '@milkdown/ctx';
 import type { InlineImageConfig } from '@milkdown/components/image-inline';
+import { TextSelection } from '@milkdown/prose/state';
 
 import type { ImageMarkdown, ImageUploadResult, UploadImageFn } from '../richTextArea.types';
 import { createRichTextAreaInlineImageConfig } from '../richTextArea.editor';
@@ -14,6 +15,7 @@ type UseRichTextImageUploadParams = {
   updateToolbarState: (ctx: Ctx) => void;
   latestOnUploadRef: React.RefObject<UploadImageFn | undefined> | undefined;
   sasToRefMap: React.RefObject<Map<string, string>>;
+  pendingImageSelectionRef: React.RefObject<{ from: number; to: number } | null>;
 };
 
 type UseRichTextImageUploadReturn = {
@@ -55,6 +57,7 @@ export const useRichTextImageUpload = ({
   updateToolbarState,
   latestOnUploadRef,
   sasToRefMap,
+  pendingImageSelectionRef,
 }: UseRichTextImageUploadParams): UseRichTextImageUploadReturn => {
   const [isUploadingImage, setIsUploadingImage] = useState(false);
 
@@ -77,8 +80,24 @@ export const useRichTextImageUpload = ({
     }
 
     editor.action((ctx) => {
+      const view = ctx.get(editorViewCtx);
+      const selection = pendingImageSelectionRef.current;
+      const maxPos = view.state.doc.content.size;
+
+      view.focus();
+
+      if (selection) {
+        const clampedFrom = Math.min(Math.max(selection.from, 0), maxPos);
+        const clampedTo = Math.min(Math.max(selection.to, 0), maxPos);
+        const from = Math.min(clampedFrom, clampedTo);
+        const to = Math.max(clampedFrom, clampedTo);
+        view.dispatch(view.state.tr.setSelection(TextSelection.create(view.state.doc, from, to)));
+      }
+
       const commands = ctx.get(commandsCtx);
       commands.call(insertImageCommand.key, image);
+
+      pendingImageSelectionRef.current = null;
       updateToolbarState(ctx);
     });
   };

--- a/base/src/components/kystverket/RichTextArea/richTextArea.editorFactory.ts
+++ b/base/src/components/kystverket/RichTextArea/richTextArea.editorFactory.ts
@@ -1,0 +1,65 @@
+import { Editor, defaultValueCtx, editorViewOptionsCtx, rootCtx } from '@milkdown/core';
+import { imageInlineComponent, inlineImageConfig } from '@milkdown/components/image-inline';
+import type { InlineImageConfig } from '@milkdown/components/image-inline';
+import { history } from '@milkdown/plugin-history';
+import { listener, listenerCtx } from '@milkdown/plugin-listener';
+import type { Ctx } from '@milkdown/ctx';
+
+import {
+  createRichTextAreaEditorDrop,
+  createRichTextAreaEditorEditable,
+  createRichTextAreaEditorPaste,
+  handleRichTextAreaEditorClick,
+  handleRichTextAreaEditorKeydown,
+  richTextCommonmarkPlugins,
+} from './richTextArea.editor';
+
+type CreateRichTextAreaEditorParams = {
+  root: HTMLElement;
+  disabled: boolean;
+  editorMarkdown: string;
+  canUploadImage: boolean;
+  dispatchImageFromFile: (file: File) => void;
+  updateInlineImageConfig: (config: InlineImageConfig) => InlineImageConfig;
+  updateToolbarState: (ctx: Ctx) => void;
+  onMarkdownUpdated: (ctx: Ctx, markdown: string) => void;
+};
+
+export const createRichTextAreaEditor = ({
+  root,
+  disabled,
+  editorMarkdown,
+  canUploadImage,
+  dispatchImageFromFile,
+  updateInlineImageConfig,
+  updateToolbarState,
+  onMarkdownUpdated,
+}: CreateRichTextAreaEditorParams) => {
+  return Editor.make()
+    .config((ctx) => {
+      ctx.set(rootCtx, root);
+      ctx.set(defaultValueCtx, editorMarkdown);
+      ctx.update(inlineImageConfig.key, updateInlineImageConfig);
+      ctx.update(editorViewOptionsCtx, (prev = {}) => ({
+        ...prev,
+        editable: createRichTextAreaEditorEditable(disabled),
+        handleDOMEvents: {
+          ...prev.handleDOMEvents,
+          click: handleRichTextAreaEditorClick,
+          keydown: handleRichTextAreaEditorKeydown,
+          paste: createRichTextAreaEditorPaste(canUploadImage, dispatchImageFromFile),
+          drop: createRichTextAreaEditorDrop(canUploadImage, dispatchImageFromFile),
+        },
+      }));
+      ctx.get(listenerCtx).markdownUpdated((listenerContext, markdown) => {
+        onMarkdownUpdated(listenerContext, markdown);
+      });
+      ctx.get(listenerCtx).selectionUpdated((listenerContext) => {
+        updateToolbarState(listenerContext);
+      });
+    })
+    .use(richTextCommonmarkPlugins)
+    .use(imageInlineComponent)
+    .use(history)
+    .use(listener);
+};

--- a/base/src/components/kystverket/RichTextArea/richTextArea.stories.tsx
+++ b/base/src/components/kystverket/RichTextArea/richTextArea.stories.tsx
@@ -104,7 +104,7 @@ export const WithImageRef: Story = {
 Bilde av Atlas
 ![Bilde_av_atlas.png](image://86062b3c-ebc8-48d0-9d08-8c282f5d8c69)`,
     label: 'Rikt tekstfelt med bildereferanse',
-    description: 'Last opp et bilde — markdownutdata vil inneholde en stabil referanse til bildet,.',
+    description: 'Last opp et bilde — markdownutdata vil inneholde en stabil referanse til bildet.',
     resolveImageRefs: async () => {
       const imageRefMap: Record<string, ResolvedImageRef> = {
         'image://86062b3c-ebc8-48d0-9d08-8c282f5d8c69': {

--- a/base/src/components/kystverket/RichTextArea/richTextArea.stories.tsx
+++ b/base/src/components/kystverket/RichTextArea/richTextArea.stories.tsx
@@ -86,12 +86,15 @@ export const WithError: Story = {
 /**
  * Demonstrates stable image references in markdown.
  *
- * `onUpload` returns both:
+ * `onImageUpload` returns both:
  * - `src` — a data URL used by the editor to display the image immediately
- * - `ref` — a stable opaque ID (e.g. Azure blob path / UUID) stored in the markdown instead of the SAS URL
+ * - `ref` — a stable opaque ID (e.g. Azure blob path / UUID) stored in the markdown instead of the SAS URL.
+ *
+ * `onImageRemove` is called with the stable ref when an image is removed from the editor,
+ * so a backend can delete the persisted image resource.
  *
  * The `onChange` output will contain `![alt](image://uuid-...)` rather than the raw data URL,
- * which is what a `MarkdownToReact` or similar renderers would receive where you implement a resolver function to provide a SAS URI or similar.
+ * and a `MarkdownToReact` resolver can map that ref to a displayable URL.
  */
 export const WithImageRef: Story = {
   args: {
@@ -119,6 +122,9 @@ Bilde av Atlas
       // Simulate a stable blob reference that would be generated server-side
       const ref = `image://${crypto.randomUUID()}`;
       return { src, ref, alt: file.name };
+    },
+    onImageRemove: async (ref: string) => {
+      alert('Removed image ' + ref);
     },
   },
   render: (args) => {

--- a/base/src/components/kystverket/RichTextArea/richTextArea.stories.tsx
+++ b/base/src/components/kystverket/RichTextArea/richTextArea.stories.tsx
@@ -5,6 +5,7 @@ import StyrbordDecorator from '../../../../storybook/styrbordDecorator';
 import { RichTextArea, RichTextAreaProps } from './richTextArea';
 
 import atlas from '@assets/img/atlas/atlas 1.jpeg';
+import { ResolvedImageRef } from '~/components/kystverket/RichTextArea/richTextArea.types';
 
 const meta = {
   title: 'Form/RichTextArea/RichTextArea',
@@ -96,17 +97,22 @@ export const WithImageRef: Story = {
   args: {
     ...defaultArgs,
 
-    value: '![bilde.png](image://86062b3c-ebc8-48d0-9d08-8c282f5d8c69)',
+    value: `
+Bilde av Atlas
+![Bilde_av_atlas.png](image://86062b3c-ebc8-48d0-9d08-8c282f5d8c69)`,
     label: 'Rikt tekstfelt med bildereferanse',
     description: 'Last opp et bilde — markdownutdata vil inneholde en stabil referanse til bildet,.',
-    resolveImageRef: (ref: string) => {
-      const imageRefMap: Record<string, { src: string }> = {
+    resolveImageRefs: async () => {
+      const imageRefMap: Record<string, ResolvedImageRef> = {
         'image://86062b3c-ebc8-48d0-9d08-8c282f5d8c69': {
           src: atlas,
         },
       };
 
-      return imageRefMap[ref]?.src;
+      await new Promise<void>((resolve) => {
+        setTimeout(resolve, 1000);
+      });
+      return imageRefMap;
     },
     onImageUpload: async (file) => {
       const src = await fileToDataUrl(file);

--- a/base/src/components/kystverket/RichTextArea/richTextArea.tsx
+++ b/base/src/components/kystverket/RichTextArea/richTextArea.tsx
@@ -58,7 +58,9 @@ const notifyRemovedManagedImages = (
 
   for (const ref of previousRefs) {
     if (!currentRefs.has(ref) && managedRefs.has(ref)) {
-      onImageRemove(ref);
+      void Promise.resolve(onImageRemove(ref)).catch(() => {
+        // Ignore remove failures here; callers should handle retry/logging
+      });
     }
   }
 };
@@ -107,23 +109,36 @@ const RichTextAreaContainer = ({
         return;
       }
 
-      const previousRefToUrlMap = new Map<string, string>(
-        Array.from(sasToRefMap.current.entries(), ([src, ref]) => [ref, src]),
-      );
-      const nextSasToRefMap = new Map<string, string>();
-      const resolvedMarkdown = await convertFromRefToImage(
-        normalizedValue,
-        resolveImageRefs,
-        nextSasToRefMap,
-        previousRefToUrlMap,
-      );
+      try {
+        const previousRefToUrlMap = new Map<string, string>(
+          Array.from(sasToRefMap.current.entries(), ([src, ref]) => [ref, src]),
+        );
+        const nextSasToRefMap = new Map<string, string>();
+        const resolvedMarkdown = await convertFromRefToImage(
+          normalizedValue,
+          resolveImageRefs,
+          nextSasToRefMap,
+          previousRefToUrlMap,
+        );
 
-      if (isCancelled) {
-        return;
+        if (isCancelled) {
+          return;
+        }
+
+        sasToRefMap.current.clear();
+        for (const [src, ref] of nextSasToRefMap.entries()) {
+          sasToRefMap.current.set(src, ref);
+        }
+
+        setEditorMarkdown(resolvedMarkdown);
+      } catch {
+        if (isCancelled) {
+          return;
+        }
+
+        sasToRefMap.current.clear();
+        setEditorMarkdown(normalizedValue);
       }
-
-      sasToRefMap.current = nextSasToRefMap;
-      setEditorMarkdown(resolvedMarkdown);
     };
 
     void resolveImages();

--- a/base/src/components/kystverket/RichTextArea/richTextArea.tsx
+++ b/base/src/components/kystverket/RichTextArea/richTextArea.tsx
@@ -2,11 +2,9 @@
 
 import { useEffect, useId, useRef, useState } from 'react';
 import { Milkdown, MilkdownProvider, useEditor } from '@milkdown/react';
-import { Editor, defaultValueCtx, editorViewCtx, editorViewOptionsCtx, rootCtx } from '@milkdown/core';
-import { imageInlineComponent, inlineImageConfig } from '@milkdown/components/image-inline';
+import { editorViewCtx } from '@milkdown/core';
 import type { InlineImageConfig } from '@milkdown/components/image-inline';
-import { history, redoCommand, undoCommand } from '@milkdown/plugin-history';
-import { listener, listenerCtx } from '@milkdown/plugin-listener';
+import { redoCommand, undoCommand } from '@milkdown/plugin-history';
 import { replaceAll } from '@milkdown/utils';
 import '@milkdown/prose/view/style/prosemirror.css';
 
@@ -18,6 +16,7 @@ import { Toolbar } from './components/Toolbar/toolbar';
 import { useRichTextToolbarState } from './hooks/useRichTextToolbarState';
 import { useRichTextLinkEditor } from './hooks/useRichTextLinkEditor';
 import { useRichTextImageUpload } from './hooks/useRichTextImageUpload';
+import { useRichTextImagePicker } from './hooks/useRichTextImagePicker';
 import {
   useRichTextCommands,
   toggleStrongCommand,
@@ -25,15 +24,8 @@ import {
   wrapInBulletListCommand,
   wrapInOrderedListCommand,
 } from './hooks/useRichTextCommands';
-import {
-  normalizeMarkdownBreakTags,
-  richTextCommonmarkPlugins,
-  createRichTextAreaEditorEditable,
-  handleRichTextAreaEditorClick,
-  handleRichTextAreaEditorKeydown,
-  createRichTextAreaEditorPaste,
-  createRichTextAreaEditorDrop,
-} from './richTextArea.editor';
+import { normalizeMarkdownBreakTags } from './richTextArea.editor';
+import { createRichTextAreaEditor } from './richTextArea.editorFactory';
 import type { ImageInsertHandler, RichTextAreaProps } from './richTextArea.types';
 import {
   convertFromRefToImage,
@@ -79,9 +71,6 @@ const RichTextAreaContainer = ({
   required = false,
   error: externalError,
 }: RichTextAreaProps) => {
-  const [internalError, setInternalError] = useState<string | undefined>(undefined);
-  const displayedError = externalError ?? internalError;
-
   // Owned here so useEditor config can close over them before useRichTextImageUpload is called.
   const sasToRefMap = useRef(new Map<string, string>());
 
@@ -92,7 +81,7 @@ const RichTextAreaContainer = ({
   const latestOnRemoveRef = useRef(onImageRemove);
   const lastKnownMarkdownRef = useRef(normalizedValue);
   const lastSyncedEditorMarkdownRef = useRef(normalizedValue);
-  const imageInputRef = useRef<HTMLInputElement | null>(null);
+  const pendingImageSelectionRef = useRef<{ from: number; to: number } | null>(null);
 
   latestOnChangeRef.current = onChange;
   latestOnUploadRef.current = onImageUpload;
@@ -161,51 +150,36 @@ const RichTextAreaContainer = ({
   // Refs above are populated before Milkdown's useEffect runs, so closures here are safe.
   const { loading, get } = useEditor(
     (root) =>
-      Editor.make()
-        .config((ctx) => {
-          ctx.set(rootCtx, root);
-          ctx.set(defaultValueCtx, editorMarkdown);
-          ctx.update(inlineImageConfig.key, updateInlineImageConfig);
-          ctx.update(editorViewOptionsCtx, (prev = {}) => ({
-            ...prev,
-            editable: createRichTextAreaEditorEditable(disabled),
-            handleDOMEvents: {
-              ...prev.handleDOMEvents,
-              click: handleRichTextAreaEditorClick,
-              keydown: handleRichTextAreaEditorKeydown,
-              paste: createRichTextAreaEditorPaste(Boolean(latestOnUploadRef.current), dispatchImageFromFile),
-              drop: createRichTextAreaEditorDrop(Boolean(latestOnUploadRef.current), dispatchImageFromFile),
-            },
-          }));
-          ctx.get(listenerCtx).markdownUpdated((_ctx, markdown) => {
-            const normalizedMarkdown = normalizeMarkdownBreakTags(markdown);
-            const transformedMarkdown = replaceImageUrlsWithRefs(normalizedMarkdown, sasToRefMap.current);
-            const previousMarkdown = lastKnownMarkdownRef.current;
+      createRichTextAreaEditor({
+        root,
+        disabled,
+        editorMarkdown,
+        canUploadImage: Boolean(latestOnUploadRef.current),
+        dispatchImageFromFile,
+        updateInlineImageConfig,
+        updateToolbarState,
+        onMarkdownUpdated: (ctx, markdown) => {
+          const normalizedMarkdown = normalizeMarkdownBreakTags(markdown);
+          const transformedMarkdown = replaceImageUrlsWithRefs(normalizedMarkdown, sasToRefMap.current);
+          const previousMarkdown = lastKnownMarkdownRef.current;
 
-            if (transformedMarkdown === previousMarkdown) {
-              updateToolbarState(_ctx);
-              return;
-            }
+          if (transformedMarkdown === previousMarkdown) {
+            updateToolbarState(ctx);
+            return;
+          }
 
-            notifyRemovedManagedImages(
-              previousMarkdown,
-              transformedMarkdown,
-              sasToRefMap.current,
-              latestOnRemoveRef.current,
-            );
+          notifyRemovedManagedImages(
+            previousMarkdown,
+            transformedMarkdown,
+            sasToRefMap.current,
+            latestOnRemoveRef.current,
+          );
 
-            lastKnownMarkdownRef.current = transformedMarkdown;
-            latestOnChangeRef.current(transformedMarkdown);
-            updateToolbarState(_ctx);
-          });
-          ctx.get(listenerCtx).selectionUpdated((listenerContext) => {
-            updateToolbarState(listenerContext);
-          });
-        })
-        .use(richTextCommonmarkPlugins)
-        .use(imageInlineComponent)
-        .use(history)
-        .use(listener),
+          lastKnownMarkdownRef.current = transformedMarkdown;
+          latestOnChangeRef.current(transformedMarkdown);
+          updateToolbarState(ctx);
+        },
+      }),
     [disabled],
   );
 
@@ -215,7 +189,20 @@ const RichTextAreaContainer = ({
     updateToolbarState,
     latestOnUploadRef,
     sasToRefMap,
+    pendingImageSelectionRef,
   });
+
+  const imagePicker = useRichTextImagePicker({
+    disabled,
+    loading,
+    canUploadImage: Boolean(onImageUpload),
+    isUploadingImage: imageUpload.isUploadingImage,
+    get,
+    pendingImageSelectionRef,
+    onImageFileInputChange: imageUpload.handleImageFileInputChange,
+  });
+
+  const displayedError = externalError ?? imagePicker.imageUploadError;
 
   // Sync stable refs so useEditor closures always call the latest implementations.
   insertImageFromFileRef.current = imageUpload.insertImageFromFile;
@@ -273,14 +260,6 @@ const RichTextAreaContainer = ({
     });
   }, [get]);
 
-  const openImageFilePicker = () => {
-    if (disabled || loading || !onImageUpload || imageUpload.isUploadingImage) {
-      return;
-    }
-
-    imageInputRef.current?.click();
-  };
-
   const showPlaceholder = !normalizedValue && Boolean(placeholder);
 
   return (
@@ -316,7 +295,7 @@ const RichTextAreaContainer = ({
             onUndo={() => runCommand(undoCommand)}
             onRedo={() => runCommand(redoCommand)}
             onLink={openLinkEditor}
-            onImageUpload={openImageFilePicker}
+            onImageUpload={imagePicker.openImageFilePicker}
             linkPopoverTarget={linkEditorAnchorId}
             onBulletList={() =>
               toggleList({
@@ -335,16 +314,12 @@ const RichTextAreaContainer = ({
             onFormatChange={handleFormatChange}
           />
           <input
-            ref={imageInputRef}
+            ref={imagePicker.imageInputRef}
             type="file"
             accept="image/*"
             hidden
             disabled={disabled || loading || imageUpload.isUploadingImage || !onImageUpload}
-            onChange={async (event) => {
-              setInternalError(undefined);
-              const { success } = await imageUpload.handleImageFileInputChange(event);
-              setInternalError(success ? undefined : 'Image failed to upload');
-            }}
+            onChange={imagePicker.handleImageFileInputChange}
           />
 
           <div

--- a/base/src/components/kystverket/RichTextArea/richTextArea.tsx
+++ b/base/src/components/kystverket/RichTextArea/richTextArea.tsx
@@ -34,7 +34,7 @@ import {
   createRichTextAreaEditorPaste,
   createRichTextAreaEditorDrop,
 } from './richTextArea.editor';
-import type { ImageInsertHandler, RichTextAreaProps } from './richTextArea.types';
+import type { ImageInsertHandler, ImageUploadResult, RichTextAreaProps } from './richTextArea.types';
 import {
   convertFromRefToImage,
   replaceImageUrlsWithRefs,
@@ -44,8 +44,9 @@ export type { RichTextAreaProps };
 const RichTextAreaContainer = ({
   value,
   onChange,
-  onImageUpload: onUpload,
-  resolveImageRef,
+  onImageUpload,
+  onImageRemove,
+  resolveImageRefs,
   placeholder,
   disabled = false,
   label,
@@ -61,17 +62,54 @@ const RichTextAreaContainer = ({
   const sasToRefMap = useRef(new Map<string, string>());
 
   const normalizedValue = normalizeMarkdownBreakTags(value ?? '');
-  const editorMarkdown = resolveImageRef
-    ? convertFromRefToImage(normalizedValue, resolveImageRef, sasToRefMap.current)
-    : normalizedValue;
+  const [editorMarkdown, setEditorMarkdown] = useState(normalizedValue);
   const latestOnChangeRef = useRef(onChange);
-  const latestOnUploadRef = useRef(onUpload);
+  const latestOnUploadRef = useRef<(file: File) => Promise<ImageUploadResult | string | null>>(async (file) =>
+    onImageUpload ? onImageUpload(file) : null,
+  );
   const lastKnownMarkdownRef = useRef(normalizedValue);
-  const lastSyncedEditorMarkdownRef = useRef(editorMarkdown);
+  const lastSyncedEditorMarkdownRef = useRef(normalizedValue);
   const imageInputRef = useRef<HTMLInputElement | null>(null);
 
   latestOnChangeRef.current = onChange;
-  latestOnUploadRef.current = onUpload;
+  latestOnUploadRef.current = async (file) => (onImageUpload ? onImageUpload(file) : null);
+
+  // Resolve stable image refs to display URLs before markdown is loaded into the editor.
+  useEffect(() => {
+    let isCancelled = false;
+
+    const resolveImages = async () => {
+      if (!resolveImageRefs) {
+        sasToRefMap.current.clear();
+        setEditorMarkdown(normalizedValue);
+        return;
+      }
+
+      const previousRefToUrlMap = new Map<string, string>(
+        Array.from(sasToRefMap.current.entries(), ([src, ref]) => [ref, src]),
+      );
+      const nextSasToRefMap = new Map<string, string>();
+      const resolvedMarkdown = await convertFromRefToImage(
+        normalizedValue,
+        resolveImageRefs,
+        nextSasToRefMap,
+        previousRefToUrlMap,
+      );
+
+      if (isCancelled) {
+        return;
+      }
+
+      sasToRefMap.current = nextSasToRefMap;
+      setEditorMarkdown(resolvedMarkdown);
+    };
+
+    void resolveImages();
+
+    return () => {
+      isCancelled = true;
+    };
+  }, [normalizedValue, resolveImageRefs]);
 
   const insertImageFromFileRef = useRef<ImageInsertHandler>(() => {});
   const inlineImageConfigUpdaterRef = useRef<(config: InlineImageConfig) => InlineImageConfig>((c) => c);
@@ -190,7 +228,7 @@ const RichTextAreaContainer = ({
   }, [get]);
 
   const openImageFilePicker = () => {
-    if (disabled || loading || !onUpload || imageUpload.isUploadingImage) {
+    if (disabled || loading || !onImageUpload || imageUpload.isUploadingImage) {
       return;
     }
 
@@ -226,7 +264,7 @@ const RichTextAreaContainer = ({
             isOrderedListActive={toolbarState.isOrderedListActive}
             selectedFormat={toolbarState.selectedFormat}
             isLinkActive={toolbarState.isLinkActive}
-            canUploadImage={Boolean(onUpload)}
+            canUploadImage={Boolean(onImageUpload)}
             onBold={() => runCommand(toggleStrongCommand)}
             onItalic={() => runCommand(toggleEmphasisCommand)}
             onUndo={() => runCommand(undoCommand)}
@@ -255,7 +293,7 @@ const RichTextAreaContainer = ({
             type="file"
             accept="image/*"
             hidden
-            disabled={disabled || loading || imageUpload.isUploadingImage || !onUpload}
+            disabled={disabled || loading || imageUpload.isUploadingImage || !onImageUpload}
             onChange={async (event) => {
               setInternalError(undefined);
               const { success } = await imageUpload.handleImageFileInputChange(event);

--- a/base/src/components/kystverket/RichTextArea/richTextArea.tsx
+++ b/base/src/components/kystverket/RichTextArea/richTextArea.tsx
@@ -34,12 +34,34 @@ import {
   createRichTextAreaEditorPaste,
   createRichTextAreaEditorDrop,
 } from './richTextArea.editor';
-import type { ImageInsertHandler, ImageUploadResult, RichTextAreaProps } from './richTextArea.types';
+import type { ImageInsertHandler, RichTextAreaProps } from './richTextArea.types';
 import {
   convertFromRefToImage,
+  getImageRefsFromMarkdown,
   replaceImageUrlsWithRefs,
 } from '~/components/kystverket/RichTextArea/utils/ImageRefUtils';
 export type { RichTextAreaProps };
+
+const notifyRemovedManagedImages = (
+  previousMarkdown: string,
+  currentMarkdown: string,
+  sasToRefMap: Map<string, string>,
+  onImageRemove?: (ref: string) => unknown,
+) => {
+  if (!onImageRemove) {
+    return;
+  }
+
+  const previousRefs = new Set(getImageRefsFromMarkdown(previousMarkdown));
+  const currentRefs = new Set(getImageRefsFromMarkdown(currentMarkdown));
+  const managedRefs = new Set(sasToRefMap.values());
+
+  for (const ref of previousRefs) {
+    if (!currentRefs.has(ref) && managedRefs.has(ref)) {
+      onImageRemove(ref);
+    }
+  }
+};
 
 const RichTextAreaContainer = ({
   value,
@@ -64,15 +86,15 @@ const RichTextAreaContainer = ({
   const normalizedValue = normalizeMarkdownBreakTags(value ?? '');
   const [editorMarkdown, setEditorMarkdown] = useState(normalizedValue);
   const latestOnChangeRef = useRef(onChange);
-  const latestOnUploadRef = useRef<(file: File) => Promise<ImageUploadResult | string | null>>(async (file) =>
-    onImageUpload ? onImageUpload(file) : null,
-  );
+  const latestOnUploadRef = useRef(onImageUpload);
+  const latestOnRemoveRef = useRef(onImageRemove);
   const lastKnownMarkdownRef = useRef(normalizedValue);
   const lastSyncedEditorMarkdownRef = useRef(normalizedValue);
   const imageInputRef = useRef<HTMLInputElement | null>(null);
 
   latestOnChangeRef.current = onChange;
-  latestOnUploadRef.current = async (file) => (onImageUpload ? onImageUpload(file) : null);
+  latestOnUploadRef.current = onImageUpload;
+  latestOnRemoveRef.current = onImageRemove;
 
   // Resolve stable image refs to display URLs before markdown is loaded into the editor.
   useEffect(() => {
@@ -143,11 +165,20 @@ const RichTextAreaContainer = ({
           ctx.get(listenerCtx).markdownUpdated((_ctx, markdown) => {
             const normalizedMarkdown = normalizeMarkdownBreakTags(markdown);
             const transformedMarkdown = replaceImageUrlsWithRefs(normalizedMarkdown, sasToRefMap.current);
+            const previousMarkdown = lastKnownMarkdownRef.current;
 
-            if (transformedMarkdown === lastKnownMarkdownRef.current) {
+            if (transformedMarkdown === previousMarkdown) {
               updateToolbarState(_ctx);
               return;
             }
+
+            notifyRemovedManagedImages(
+              previousMarkdown,
+              transformedMarkdown,
+              sasToRefMap.current,
+              latestOnRemoveRef.current,
+            );
+
             lastKnownMarkdownRef.current = transformedMarkdown;
             latestOnChangeRef.current(transformedMarkdown);
             updateToolbarState(_ctx);

--- a/base/src/components/kystverket/RichTextArea/richTextArea.types.ts
+++ b/base/src/components/kystverket/RichTextArea/richTextArea.types.ts
@@ -1,4 +1,5 @@
 import type { CmdKey } from '@milkdown/core';
+import { MaybePromise } from '~/utils/utility.types';
 
 export type RichTextAreaProps = {
   value: string | null | undefined;
@@ -11,14 +12,18 @@ export type RichTextAreaProps = {
   optional?: boolean | string;
   required?: boolean | string;
   error?: string;
-  /** For when image is uploaded, to give it a ref */
-  onImageUpload?: UploadImageFn;
-  resolveImageRef?: (ref: string) => string | null | undefined;
+  /** Optional upload handler that returns a display src and optional stable image ref. */
+  onImageUpload?: (file: File) => Promise<ImageUploadResult | null>;
+  /** Optional remove handler for deleting persisted images by stable ref. */
+  onImageRemove?: (ref: string) => Promise<void>;
+  /** Optional resolver that maps image refs in markdown to renderable image sources. */
+  resolveImageRefs?: (refs?: string[]) => MaybePromise<Record<string, ResolvedImageRef>>;
 };
 
 export type ToolbarCommand<T = unknown> = { key: CmdKey<T>; value?: T };
 
 export type ImageMarkdown = { src: string; alt?: string };
+export type ResolvedImageRef = ImageMarkdown | undefined;
 
 export type ImageUploadResult = { src: string; ref?: string; alt?: string };
 

--- a/base/src/components/kystverket/RichTextArea/utils/ImageRefUtils.ts
+++ b/base/src/components/kystverket/RichTextArea/utils/ImageRefUtils.ts
@@ -1,17 +1,31 @@
+import { MaybePromise } from '~/utils/utility.types';
+
 type ResolvedImageRef = { src: string; alt?: string } | string | null | undefined;
 
-export const convertFromRefToImage = (
+export const convertFromRefToImage = async (
   markdown: string,
-  resolveImageRef: (ref: string) => ResolvedImageRef,
+  resolveImageRefs: (refs: string[]) => MaybePromise<Record<string, ResolvedImageRef>>,
   urlToRefMap?: Map<string, string>,
+  previousRefToUrlMap?: Map<string, string>,
 ) => {
   const imageRegex = /!\[([^\]]*)\]\(([^)\s]+)(?:\s+"([^"]*)")?\)/g;
+  const uniqueRefs = Array.from(new Set(Array.from(markdown.matchAll(imageRegex), ([, , ref]) => ref)));
+
+  const resolvedImageRefs = await resolveImageRefs(uniqueRefs);
 
   return markdown.replace(imageRegex, (fullMatch, alt: string, ref: string, title: string | undefined) => {
-    const resolvedImageRef = resolveImageRef(ref);
+    const resolvedImageRef = resolvedImageRefs[ref];
 
     if (resolvedImageRef === undefined || resolvedImageRef === null) {
-      return fullMatch;
+      const fallbackSrc = previousRefToUrlMap?.get(ref);
+
+      if (!fallbackSrc) {
+        return fullMatch;
+      }
+
+      const titlePart = title ? ` "${title}"` : '';
+      urlToRefMap?.set(fallbackSrc, ref);
+      return `![${alt}](${fallbackSrc}${titlePart})`;
     }
 
     const resolvedSrc = typeof resolvedImageRef === 'string' ? resolvedImageRef : resolvedImageRef.src;

--- a/base/src/components/kystverket/RichTextArea/utils/ImageRefUtils.ts
+++ b/base/src/components/kystverket/RichTextArea/utils/ImageRefUtils.ts
@@ -2,14 +2,18 @@ import { MaybePromise } from '~/utils/utility.types';
 
 type ResolvedImageRef = { src: string; alt?: string } | string | null | undefined;
 
+const imageRegex = /!\[([^\]]*)\]\(([^)\s]+)(?:\s+"([^"]*)")?\)/g;
+
+export const getImageRefsFromMarkdown = (markdown: string): string[] =>
+  Array.from(new Set(Array.from(markdown.matchAll(imageRegex), ([, , ref]) => ref)));
+
 export const convertFromRefToImage = async (
   markdown: string,
   resolveImageRefs: (refs: string[]) => MaybePromise<Record<string, ResolvedImageRef>>,
   urlToRefMap?: Map<string, string>,
   previousRefToUrlMap?: Map<string, string>,
 ) => {
-  const imageRegex = /!\[([^\]]*)\]\(([^)\s]+)(?:\s+"([^"]*)")?\)/g;
-  const uniqueRefs = Array.from(new Set(Array.from(markdown.matchAll(imageRegex), ([, , ref]) => ref)));
+  const uniqueRefs = getImageRefsFromMarkdown(markdown);
 
   const resolvedImageRefs = await resolveImageRefs(uniqueRefs);
 

--- a/base/src/utils/utility.types.ts
+++ b/base/src/utils/utility.types.ts
@@ -1,0 +1,1 @@
+export type MaybePromise<T> = T | Promise<T>;

--- a/package-lock.json
+++ b/package-lock.json
@@ -54,7 +54,7 @@
     },
     "base": {
       "name": "@kystverket/styrbord",
-      "version": "1.8.3",
+      "version": "1.8.4",
       "license": "ISC",
       "dependencies": {
         "@digdir/designsystemet-css": "~1.15.0",


### PR DESCRIPTION
# Beskrivelse
- Legge til så resolveImageRefs kan være både sync og async
- Lagt inn `onImageRemove` listener på RichTextArea 
- Litt diverse cleanup