### PR TITLE
Gjort komponenter som bruker FileRetriever mer bakoverkompatible

### DIFF
--- a/base/README.md
+++ b/base/README.md
@@ -41,6 +41,10 @@ Styrbords design tokens hentes fra [@Kystverket/styrbord-tokens](https://github.
 
 ## Endringslogg
 
+### 2026-06-22 -- v1.9.9
+
+Lagt inn en ny context for å hente filer som er lastet opp til RichTextArea, MarkdownToReact og FileUploader kalt `FileRetrieverContext`. Uten en provider til denne så vil komponentene fortsatt fungere, men preview av opplastede/refererte filer vil ikke bli vist.
+
 ### 2026-06-09 -- v1.9.0
 
 Oppdatert RichTextArea og MarkdownToReact til å bruke FileUploader sin context for å håndtere henting av fil-informasjon gjennom `deriveFileInfosFromStorageIds`

--- a/base/package.json
+++ b/base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kystverket/styrbord",
-  "version": "1.9.8",
+  "version": "1.9.9",
   "description": "",
   "type": "module",
   "repository": {

--- a/base/src/components/kystverket/FileUploader/FileRetriever.context.tsx
+++ b/base/src/components/kystverket/FileUploader/FileRetriever.context.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext } from 'react';
+import { createContext } from 'react';
 import type { DeriveFileInfosFromStorageIds } from '~/utils/fileInfoResolver';
 
 export interface FileRetrieverContextProps {
@@ -6,13 +6,3 @@ export interface FileRetrieverContextProps {
 }
 
 export const FileRetrieverContext = createContext<FileRetrieverContextProps | null>(null);
-
-export const useFileRetrieverContext = (): FileRetrieverContextProps => {
-  const context = useContext(FileRetrieverContext);
-
-  if (!context) {
-    throw new Error('FileRetrieverContext.Provider is missing in the component tree.');
-  }
-
-  return context;
-};

--- a/base/src/components/kystverket/FileUploader/FileUploader.stories.tsx
+++ b/base/src/components/kystverket/FileUploader/FileUploader.stories.tsx
@@ -129,7 +129,7 @@ const existingFilesProvider = async (): Promise<ExistingFilesProviderItem[]> => 
         {
           contextId: 'existing-3',
           fileName: 'screenshot.png',
-          storageId: 'storage-id-3',
+          storageId: '1',
           contentType: 'image/png',
           status: 'uploaded',
         },
@@ -149,7 +149,7 @@ const existingFilesProvider = async (): Promise<ExistingFilesProviderItem[]> => 
         {
           contextId: 'existing-test2-2',
           fileName: 'image1.jpg',
-          storageId: 'storage-id-test2-2',
+          storageId: '2',
           contentType: 'image/jpeg',
           status: 'uploaded',
         },
@@ -163,7 +163,7 @@ const existingFilesProvider = async (): Promise<ExistingFilesProviderItem[]> => 
         {
           contextId: 'existing-test2-4',
           fileName: 'screenshot.png',
-          storageId: 'storage-id-test2-4',
+          storageId: '3',
           contentType: 'image/png',
           status: 'uploaded',
         },

--- a/base/src/components/kystverket/FileUploader/FileUploader.tsx
+++ b/base/src/components/kystverket/FileUploader/FileUploader.tsx
@@ -7,7 +7,7 @@ import classes from './FileUploader.module.css';
 import { Icon, LabelContent } from '~/main';
 import exifr from 'exifr';
 import { FileUploaderContext } from './FileUploader.context';
-import { useFileRetrieverContext } from './FileRetriever.context';
+import { FileRetrieverContext } from './FileRetriever.context';
 import { FileUploaderItem } from './item/FileUploaderItem';
 import { onFilesChanged } from '~/components/kystverket/FileUploader/FileUploaderHelpers';
 import {
@@ -93,7 +93,7 @@ export const FileUploader = ({
   const t = scopedT('fileUploader');
 
   const fileUploaderContext = useContext(FileUploaderContext);
-  const { deriveFileInfosFromStorageIds } = useFileRetrieverContext();
+  const fileRetrieverContext = useContext(FileRetrieverContext);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const fileCameraInputRef = useRef<HTMLInputElement>(null);
   const dialogRef = useRef<ExistingFilesDialogHandle>(null);
@@ -103,7 +103,7 @@ export const FileUploader = ({
   const [storageIdToExtraFileInfo, setStorageIdToExtraFileInfo] = useState<Map<string, ExtraFileInfo>>(new Map());
 
   useEffect(() => {
-    if (!allowFilePreview) {
+    if (!allowFilePreview || !fileRetrieverContext) {
       setPreviewFiles([]);
       setStorageIdToPreviewIndex(new Map());
       setStorageIdToExtraFileInfo(new Map());
@@ -117,7 +117,7 @@ export const FileUploader = ({
       const storageIds = files
         .filter((f) => f.status === 'uploaded' && f.storageId)
         .map((f) => f.storageId!) as string[];
-      const extraFileInfos = await deriveFileInfosFromStorageIds(storageIds);
+      const extraFileInfos = await fileRetrieverContext.deriveFileInfosFromStorageIds(storageIds);
       const extraInfoMap = createStorageIdToExtraFileInfoMap(extraFileInfos);
 
       files.forEach((file) => {
@@ -154,7 +154,7 @@ export const FileUploader = ({
       setStorageIdToExtraFileInfo(extraInfoMap);
     };
     void fetchPreviewFiles();
-  }, [allowFilePreview, files, deriveFileInfosFromStorageIds]);
+  }, [allowFilePreview, files, fileRetrieverContext]);
 
   const onUploadFile = (uploadedFiles: File[]) => {
     Promise.all(

--- a/base/src/components/kystverket/FileUploader/existingFilesDialog/ExistingFilesDialog.tsx
+++ b/base/src/components/kystverket/FileUploader/existingFilesDialog/ExistingFilesDialog.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, useEffect, useImperativeHandle, useState } from 'react';
+import { forwardRef, useContext, useEffect, useImperativeHandle, useRef, useState } from 'react';
 import {
   Box,
   FileInfo,
@@ -12,8 +12,8 @@ import {
   type ExtraFileInfo,
   SlotDialog,
 } from '~/main';
-import { useFileRetrieverContext } from '~/components/kystverket/FileUploader/FileRetriever.context';
 import classes from './ExistingFilesDialog.module.css';
+import { FileRetrieverContext } from '../FileRetriever.context';
 import { convertBytesToReadable } from '~/utils/convertBytesToReadable';
 import { ExistingFilesProviderItem } from '~/components/kystverket/FileUploader/FileUploader';
 import { createStorageIdToExtraFileInfoMap } from '~/utils/fileInfoResolver';
@@ -34,7 +34,6 @@ export interface ExistingFilesDialogHandle {
 export const ExistingFilesDialog = forwardRef<ExistingFilesDialogHandle, ExistingFilesDialogProps>(
   function ExistingFilesDialog({ t, existingFiles, existingFilesProvider, onConfirm }, ref) {
     const [loadingAllExistingFiles, setLoadingAllExistingFiles] = useState(false);
-    const { deriveFileInfosFromStorageIds } = useFileRetrieverContext();
 
     const [existingFilesCollection, setExistingFilesCollection] = useState<ExistingFilesProviderItem[]>([]);
     const [selectedFileCollection, setSelectedFileCollection] = useState<ExistingFilesProviderItem>();
@@ -45,9 +44,23 @@ export const ExistingFilesDialog = forwardRef<ExistingFilesDialogHandle, Existin
 
     const [storageIdToExtraFileInfo, setStorageIdToExtraFileInfo] = useState<Map<string, ExtraFileInfo>>(new Map());
 
+    const fileRetrieverContext = useContext(FileRetrieverContext);
+    const hasLoggedMissingFileResolverRef = useRef(false);
+
     useEffect(() => {
       if (!existingFilesCollection || existingFilesCollection.length === 0) {
         setStorageIdToExtraFileInfo(new Map());
+      }
+
+      if (!fileRetrieverContext) {
+        const storageIds = existingFilesCollection.flatMap((f) => f.files).filter((f) => f.storageId);
+        if (!hasLoggedMissingFileResolverRef.current && storageIds.length > 0) {
+          console.error(
+            'ExistingFilesDialog: file preview support is enabled but FileRetrieverContext.Provider is missing. Provide a file resolver to enable file preview.',
+          );
+          hasLoggedMissingFileResolverRef.current = true;
+        }
+        return;
       }
 
       const fetchPreviewFiles = async () => {
@@ -57,12 +70,12 @@ export const ExistingFilesDialog = forwardRef<ExistingFilesDialogHandle, Existin
             .filter((f) => f.storageId)
             .map((f) => f.storageId!) as string[],
         );
-        const extraFileInfos = await deriveFileInfosFromStorageIds([...storageIds]);
+        const extraFileInfos = await fileRetrieverContext.deriveFileInfosFromStorageIds([...storageIds]);
         const extraInfoMap = createStorageIdToExtraFileInfoMap(extraFileInfos);
         setStorageIdToExtraFileInfo(extraInfoMap);
       };
       void fetchPreviewFiles();
-    }, [existingFilesCollection, deriveFileInfosFromStorageIds]);
+    }, [existingFilesCollection, fileRetrieverContext]);
 
     useImperativeHandle(
       ref,

--- a/base/src/components/kystverket/MarkdownToReact/markdownToReact.tsx
+++ b/base/src/components/kystverket/MarkdownToReact/markdownToReact.tsx
@@ -1,9 +1,10 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useContext, useEffect, useMemo, useRef, useState } from 'react';
 import ReactMarkdown from 'react-markdown';
 import styles from './markdownToReact.module.css';
 import { Link, Paragraph } from '~/main';
 import { convertFromRefToImage } from '~/components/kystverket/RichTextArea/utils/ImageRefUtils';
-import { useFileRetrieverContext } from '~/components/kystverket/FileUploader/FileRetriever.context';
+import { FileRetrieverContext } from '~/components/kystverket/FileUploader/FileRetriever.context';
+import type { DeriveFileInfosFromStorageIds } from '~/utils/fileInfoResolver';
 
 export type MarkdownToReactProps = {
   markdown: string;
@@ -11,7 +12,23 @@ export type MarkdownToReactProps = {
 
 // Overskrifter (h1-h6) rendres som <Paragraph> med tanke på dokumenthierarki (enn så lenge, dette må vi komme tilbake til etter hvert)
 const MarkdownToReact = ({ markdown }: MarkdownToReactProps) => {
-  const { deriveFileInfosFromStorageIds } = useFileRetrieverContext();
+  const fileRetrieverContext = useContext(FileRetrieverContext);
+  const hasLoggedMissingFileResolverRef = useRef(false);
+
+  const deriveFileInfosFromStorageIds: DeriveFileInfosFromStorageIds = (storageIds) => {
+    if (!fileRetrieverContext) {
+      if (!hasLoggedMissingFileResolverRef.current && storageIds.length > 0) {
+        console.error(
+          'MarkdownToReact: image reference resolution needs FileRetrieverContext.Provider, but none is mounted.',
+        );
+        hasLoggedMissingFileResolverRef.current = true;
+      }
+
+      return [];
+    }
+
+    return fileRetrieverContext.deriveFileInfosFromStorageIds(storageIds);
+  };
 
   const normalizedMarkdown = useMemo(() => markdown.replaceAll(/\n{3,}/g, '\n\n\u00A0\n\n'), [markdown]);
   const [renderedMarkdown, setRenderedMarkdown] = useState(normalizedMarkdown);
@@ -42,7 +59,7 @@ const MarkdownToReact = ({ markdown }: MarkdownToReactProps) => {
     return () => {
       isCancelled = true;
     };
-  }, [normalizedMarkdown, deriveFileInfosFromStorageIds]);
+  }, [normalizedMarkdown, fileRetrieverContext]);
 
   return (
     <div className={styles.markdownToReact}>

--- a/base/src/components/kystverket/RichTextArea/richTextArea.tsx
+++ b/base/src/components/kystverket/RichTextArea/richTextArea.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useId, useRef, useState } from 'react';
+import { useContext, useEffect, useId, useRef, useState } from 'react';
 import { Milkdown, MilkdownProvider, useEditor } from '@milkdown/react';
 import { editorViewCtx } from '@milkdown/core';
 import type { InlineImageConfig } from '@milkdown/components/image-inline';
@@ -11,7 +11,7 @@ import '@milkdown/prose/view/style/prosemirror.css';
 import classes from './richTextArea.module.css';
 
 import { Fieldset, LabelContent, ValidationMessage } from '~/main';
-import { useFileRetrieverContext } from '../FileUploader/FileRetriever.context';
+import { FileRetrieverContext } from '../FileUploader/FileRetriever.context';
 import LinkEditor from './components/LinkEditor/linkEditor';
 import { Toolbar } from './components/Toolbar/toolbar';
 import { useRichTextToolbarState } from './hooks/useRichTextToolbarState';
@@ -33,6 +33,7 @@ import {
   getImageRefsFromMarkdown,
   replaceImageUrlsWithRefs,
 } from '~/components/kystverket/RichTextArea/utils/ImageRefUtils';
+import type { DeriveFileInfosFromStorageIds } from '~/utils/fileInfoResolver';
 export type { RichTextAreaProps };
 
 const notifyRemovedManagedImages = (
@@ -74,7 +75,22 @@ const RichTextAreaContainer = ({
   // Owned here so useEditor config can close over them before useRichTextImageUpload is called.
   const sasToRefMap = useRef(new Map<string, string>());
   const refToPreviewMap = useRef(new Map<string, string>());
-  const { deriveFileInfosFromStorageIds } = useFileRetrieverContext();
+  const fileRetrieverContext = useContext(FileRetrieverContext);
+  const hasLoggedMissingFileResolverRef = useRef(false);
+
+  const deriveFileInfosFromStorageIds: DeriveFileInfosFromStorageIds = (storageIds) => {
+    if (!fileRetrieverContext) {
+      if (!hasLoggedMissingFileResolverRef.current && storageIds.length > 0) {
+        console.error(
+          'RichTextArea: image upload/ref support is enabled but FileRetrieverContext.Provider is missing. Provide a file resolver to enable image reference resolution.',
+        );
+        hasLoggedMissingFileResolverRef.current = true;
+      }
+      return [];
+    }
+
+    return fileRetrieverContext.deriveFileInfosFromStorageIds(storageIds);
+  };
 
   const normalizedValue = normalizeMarkdownBreakTags(value ?? '');
   const [editorMarkdown, setEditorMarkdown] = useState(normalizedValue);
@@ -134,7 +150,7 @@ const RichTextAreaContainer = ({
     return () => {
       isCancelled = true;
     };
-  }, [normalizedValue, deriveFileInfosFromStorageIds]);
+  }, [normalizedValue, fileRetrieverContext]);
 
   const insertImageFromFileRef = useRef<ImageInsertHandler>(() => {});
   const inlineImageConfigUpdaterRef = useRef<(config: InlineImageConfig) => InlineImageConfig>((c) => c);

--- a/base/src/main.ts
+++ b/base/src/main.ts
@@ -105,7 +105,6 @@ export {
 } from './components/kystverket/FileUploader/FileUploader.context';
 export {
   FileRetrieverContext,
-  useFileRetrieverContext,
   type FileRetrieverContextProps,
 } from './components/kystverket/FileUploader/FileRetriever.context';
 export type * from './components/kystverket/FileUploader/FileUploader.types';

--- a/package-lock.json
+++ b/package-lock.json
@@ -54,7 +54,7 @@
     },
     "base": {
       "name": "@kystverket/styrbord",
-      "version": "1.9.8",
+      "version": "1.9.9",
       "license": "ISC",
       "dependencies": {
         "@digdir/designsystemet-css": "~1.15.0",


### PR DESCRIPTION
# Beskrivelse
La inn en hotfix, da forrige oppdatering gjør at de som bruker FileUploader eller lignende får en crash, endret til at denne nå sender en error log i stedet.