### PR TITLE
fix(base): Legg til subtle farge til Chip

### DIFF
--- a/base/src/components/designsystemet/Chip/Chip.colors.override.scss
+++ b/base/src/components/designsystemet/Chip/Chip.colors.override.scss
@@ -1,0 +1,20 @@
+.ds-chip[data-color='primary/subtle'] {
+  background-color: var(--ds-color-primary-surface-tinted);
+  color: var(--ds-color-primary-text-default);
+  &:hover {
+    background-color: var(--ds-color-primary-surface-hover);
+  }
+  &:active {
+    background-color: var(--ds-color-primary-surface-active);
+  }
+}
+.ds-chip[data-color='neutral/subtle'] {
+  background-color: var(--ds-color-neutral-surface-tinted);
+  color: var(--ds-color-neutral-text-default);
+  &:hover {
+    background-color: var(--ds-color-neutral-surface-hover);
+  }
+  &:active {
+    background-color: var(--ds-color-neutral-surface-active);
+  }
+}

--- a/base/src/components/designsystemet/Chip/Chip.override.scss
+++ b/base/src/components/designsystemet/Chip/Chip.override.scss
@@ -1,3 +1,5 @@
+@use './Chip.colors.override.scss';
+
 .ds-chip {
   gap: 0;
 }

--- a/base/src/components/designsystemet/Chip/Chip.stories.tsx
+++ b/base/src/components/designsystemet/Chip/Chip.stories.tsx
@@ -8,16 +8,20 @@ type ChipVariant = (typeof chipVariants)[number];
 type ChipStoryArgs = {
   variant: ChipVariant;
   label: string;
+  color: ChipColor;
+  disabled: boolean;
 };
 
 type ChipColor = NonNullable<ChipButtonProps['data-color']>;
 
-const chipColors: ChipColor[] = ['none', 'neutral'];
+const chipColors: ChipColor[] = ['primary', 'neutral', 'primary/subtle', 'neutral/subtle'];
 const sizes = ['sm', 'md', 'lg'] as const;
 
 const defaultVariantArgs: ChipStoryArgs = {
   variant: 'Radio',
   label: 'Nynorsk',
+  color: 'none',
+  disabled: false,
 };
 
 const variantArgTypes = {
@@ -28,13 +32,36 @@ const variantArgTypes = {
   label: {
     control: { type: 'text' as const },
   },
+  color: {
+    control: { type: 'select' as const },
+    description: 'Subtle is mainly used for Removable variant',
+    options: chipColors,
+  },
+  disabled: {
+    control: { type: 'boolean' as const },
+  },
 };
 
-const renderChip = (variant: ChipVariant, label: string, size?: 'sm' | 'md' | 'lg', color?: ChipColor) => {
+const renderChip = (
+  variant: ChipVariant,
+  label: string,
+  size?: 'sm' | 'md' | 'lg',
+  color?: ChipColor,
+  disabled?: boolean,
+  ...rest: undefined[]
+) => {
   switch (variant) {
     case 'Radio': {
       return (
-        <Chip.Radio data-size={size} data-color={color} name="preview-radio" value={size ?? 'preview'} defaultChecked>
+        <Chip.Radio
+          {...rest}
+          data-size={size}
+          data-color={color}
+          disabled={disabled}
+          name="preview-radio"
+          value={size ?? 'preview'}
+          defaultChecked
+        >
           {label}
         </Chip.Radio>
       );
@@ -42,8 +69,10 @@ const renderChip = (variant: ChipVariant, label: string, size?: 'sm' | 'md' | 'l
     case 'Checkbox': {
       return (
         <Chip.Checkbox
+          {...rest}
           data-size={size}
           data-color={color}
+          disabled={disabled}
           name="preview-checkbox"
           value={size ?? 'preview'}
           defaultChecked
@@ -54,14 +83,14 @@ const renderChip = (variant: ChipVariant, label: string, size?: 'sm' | 'md' | 'l
     }
     case 'Removable': {
       return (
-        <Chip.Removable data-size={size} data-color={color} aria-label={`Slett ${label}`}>
+        <Chip.Removable {...rest} data-size={size} data-color={color} disabled={disabled} aria-label={`Slett ${label}`}>
           {label}
         </Chip.Removable>
       );
     }
     case 'Button': {
       return (
-        <Chip.Button data-size={size} data-color={color}>
+        <Chip.Button {...rest} data-size={size} data-color={color} disabled={disabled}>
           {label}
         </Chip.Button>
       );
@@ -88,7 +117,7 @@ export default meta;
 type Story = StoryObj<ChipStoryArgs>;
 
 export const Preview: Story = {
-  render: ({ variant, label }) => renderChip(variant, label),
+  render: ({ variant, label, color, disabled }) => renderChip(variant, label, 'md', color, disabled),
   args: defaultVariantArgs,
   argTypes: variantArgTypes,
 };
@@ -97,10 +126,12 @@ export const Preview: Story = {
  * Go into the story itself to have an option to switch between variants
  */
 export const Sizes: Story = {
-  render: ({ variant, label }) => (
+  render: ({ variant, label, disabled }) => (
     <Box gap={8}>
       {sizes.map((size) => {
-        return <span key={size}>{renderChip(variant, `${label} ${size.toUpperCase()}`, size)}</span>;
+        return (
+          <span key={size}>{renderChip(variant, `${label} ${size.toUpperCase()}`, size, undefined, disabled)}</span>
+        );
       })}
     </Box>
   ),
@@ -109,10 +140,10 @@ export const Sizes: Story = {
 };
 
 export const Colors: Story = {
-  render: ({ variant, label }) => (
+  render: ({ variant, label, disabled }) => (
     <Box gap={8}>
       {chipColors.map((color) => {
-        return <span key={color}>{renderChip(variant, `${label} ${color}`, 'md', color)}</span>;
+        return <span key={color}>{renderChip(variant, `${label} ${color}`, 'md', color, disabled)}</span>;
       })}
     </Box>
   ),

--- a/base/src/components/designsystemet/Chip/Chip.stories.tsx
+++ b/base/src/components/designsystemet/Chip/Chip.stories.tsx
@@ -14,7 +14,7 @@ type ChipStoryArgs = {
 
 type ChipColor = NonNullable<ChipButtonProps['data-color']>;
 
-const chipColors: ChipColor[] = ['primary', 'neutral', 'primary/subtle', 'neutral/subtle'];
+const chipColors: ChipColor[] = ['none', 'primary', 'neutral', 'primary/subtle', 'neutral/subtle'];
 const sizes = ['sm', 'md', 'lg'] as const;
 
 const defaultVariantArgs: ChipStoryArgs = {
@@ -48,13 +48,11 @@ const renderChip = (
   size?: 'sm' | 'md' | 'lg',
   color?: ChipColor,
   disabled?: boolean,
-  ...rest: undefined[]
 ) => {
   switch (variant) {
     case 'Radio': {
       return (
         <Chip.Radio
-          {...rest}
           data-size={size}
           data-color={color}
           disabled={disabled}
@@ -69,7 +67,6 @@ const renderChip = (
     case 'Checkbox': {
       return (
         <Chip.Checkbox
-          {...rest}
           data-size={size}
           data-color={color}
           disabled={disabled}
@@ -83,14 +80,14 @@ const renderChip = (
     }
     case 'Removable': {
       return (
-        <Chip.Removable {...rest} data-size={size} data-color={color} disabled={disabled} aria-label={`Slett ${label}`}>
+        <Chip.Removable data-size={size} data-color={color} disabled={disabled} aria-label={`Slett ${label}`}>
           {label}
         </Chip.Removable>
       );
     }
     case 'Button': {
       return (
-        <Chip.Button {...rest} data-size={size} data-color={color} disabled={disabled}>
+        <Chip.Button data-size={size} data-color={color} disabled={disabled}>
           {label}
         </Chip.Button>
       );

--- a/base/src/components/designsystemet/Chip/Chip.tsx
+++ b/base/src/components/designsystemet/Chip/Chip.tsx
@@ -19,15 +19,13 @@ export const ChipButton: FC<ChipButtonProps & { ref?: React.Ref<HTMLButtonElemen
   );
 };
 
-export const ChipRemovable: FC<ChipRemovableProps & { ref?: React.Ref<HTMLButtonElement>; subtle?: boolean }> = ({
+export const ChipRemovable: FC<ChipRemovableProps & { ref?: React.Ref<HTMLButtonElement> }> = ({
   children,
-  subtle,
-  className,
   ref,
   ...rest
 }) => {
   return (
-    <DSChip.Removable className={[subtle && 'subtle', className].filter(Boolean).join(' ')} ref={ref} {...rest}>
+    <DSChip.Removable ref={ref} {...rest}>
       <span>{children}</span>
     </DSChip.Removable>
   );

--- a/base/src/components/designsystemet/Chip/Chip.tsx
+++ b/base/src/components/designsystemet/Chip/Chip.tsx
@@ -19,13 +19,15 @@ export const ChipButton: FC<ChipButtonProps & { ref?: React.Ref<HTMLButtonElemen
   );
 };
 
-export const ChipRemovable: FC<ChipRemovableProps & { ref?: React.Ref<HTMLButtonElement> }> = ({
+export const ChipRemovable: FC<ChipRemovableProps & { ref?: React.Ref<HTMLButtonElement>; subtle?: boolean }> = ({
   children,
+  subtle,
+  className,
   ref,
   ...rest
 }) => {
   return (
-    <DSChip.Removable ref={ref} {...rest}>
+    <DSChip.Removable className={[subtle && 'subtle', className].filter(Boolean).join(' ')} ref={ref} {...rest}>
       <span>{children}</span>
     </DSChip.Removable>
   );


### PR DESCRIPTION
# Beskrivelse
Legger inn fargene `primary/subtle` og `neutral/subtle` i chip
(Brukes hovedsakelig av removable)

<img width="141" height="82" alt="image" src="https://github.com/user-attachments/assets/0e1a0f21-4d05-424e-8fe4-82782baf172d" />
<img width="167" height="71" alt="image" src="https://github.com/user-attachments/assets/a976140e-4838-4e9d-b477-7ecd4fae3a51" />


Refs: SAK-929