### PR TITLE
fix(base): Add ClassName and Style prop to SlotDialog

### DIFF
--- a/base/src/components/kystverket/SlotDialog/SlotDialog.tsx
+++ b/base/src/components/kystverket/SlotDialog/SlotDialog.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, useContext } from 'react';
+import { CSSProperties, ReactNode, useContext } from 'react';
 import { Box, Dialog, Heading, Paragraph, type DialogSize } from '~/main';
 import classes from './SlotDialog.module.css';
 import { SlotDialogButtons } from '~/components/kystverket/SlotDialog/Buttons/SlotDialogButtons';
@@ -12,6 +12,7 @@ export interface SlotDialogProps {
   onClose?: () => void;
   ref?: React.Ref<HTMLDialogElement>;
   className?: string;
+  style?: CSSProperties;
 
   /**Should be enabled with long content */
   longContent?: boolean;
@@ -30,6 +31,7 @@ function SlotDialogRoot({
   children,
   longContent,
   size,
+  style,
   className = '',
 }: Readonly<SlotDialogProps>) {
   const DialogBlockClasses = `${classes.dialogBlockBase} ${longContent ? classes.longContent : ''}`;
@@ -41,6 +43,7 @@ function SlotDialogRoot({
         onClose={onClose}
         ref={ref}
         size={size}
+        style={style}
         className={`${classes.slotDialogOverrides} ${className}`}
         closedby="any"
       >

--- a/base/src/components/kystverket/SlotDialog/SlotDialog.tsx
+++ b/base/src/components/kystverket/SlotDialog/SlotDialog.tsx
@@ -11,6 +11,7 @@ export interface SlotDialogProps {
   open?: boolean;
   onClose?: () => void;
   ref?: React.Ref<HTMLDialogElement>;
+  className?: string;
 
   /**Should be enabled with long content */
   longContent?: boolean;
@@ -29,6 +30,7 @@ function SlotDialogRoot({
   children,
   longContent,
   size,
+  className = '',
 }: Readonly<SlotDialogProps>) {
   const DialogBlockClasses = `${classes.dialogBlockBase} ${longContent ? classes.longContent : ''}`;
 
@@ -39,7 +41,7 @@ function SlotDialogRoot({
         onClose={onClose}
         ref={ref}
         size={size}
-        className={classes.slotDialogOverrides}
+        className={`${classes.slotDialogOverrides} ${className}`}
         closedby="any"
       >
         <Box gap={4} className={`${classes.headerBlock} ${DialogBlockClasses}`}>


### PR DESCRIPTION
# Beskrivelse
Add ClassName and Style prop to Dialog to allow for more customizing, such as width
