### PR TITLE
fix(base): Remove descender space below icon

### DIFF
--- a/base/src/components/kystverket/Icon/icon.module.css
+++ b/base/src/components/kystverket/Icon/icon.module.css
@@ -44,24 +44,25 @@
     border-radius: var(--ds-border-radius-lg);
   }
   .container {
-    user-select: none;
-    font-weight: var(--ds-font-weight-regular);
+    display: flex; /* To avoid "descender space" below icon */
     position: relative;
-    height: var(--icon-container-size) !important;
     width: var(--icon-container-size) !important;
+    height: var(--icon-container-size) !important;
+    font-weight: var(--ds-font-weight-regular);
+    user-select: none;
   }
   .icon {
-    font-size: var(--icon-font-size) !important;
-    height: var(--icon-size) !important;
     width: var(--icon-size) !important;
+    height: var(--icon-size) !important;
+    font-size: var(--icon-font-size) !important;
   }
   .indicator {
     position: absolute;
     top: 50%;
     left: 50%;
+    padding: calc(var(--icon-font-size) * 0.05) !important;
     border-radius: 999px;
     font-size: calc(var(--icon-font-size) * 0.5) !important;
-    padding: calc(var(--icon-font-size) * 0.05) !important;
   }
   .noBackground .indicator {
     background: var(--ds-color-primary-surface-default);


### PR DESCRIPTION
# Beskrivelse
- Fjernet ekstra space under ikon, for at alignment på sidene skal være likt
- Sortert css fil


pre-fix (legg merke til space under de ikonene som ikke har farget bakgrunn)
<img width="1227" height="676" alt="image" src="https://github.com/user-attachments/assets/8a9a003a-0653-4316-a151-0ad1ff107b1c" />

post-fix
<img width="1862" height="685" alt="image" src="https://github.com/user-attachments/assets/3f6a723d-3855-46b6-a4a3-7ab518feac82" />

